### PR TITLE
Add pytest-copier tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ crate preconfigured with sensible defaults and continuous integration.
 Use this template when you need a minimal scaffold for CLI tools or small
 utilities. The included workflow ensures coverage metrics are collected and
 linters run from the very first commit.
+
+## Testing
+
+Install the test requirements and run `pytest` to ensure the template renders
+correctly using `pytest-copier`. Additional details are in
+[`docs/testing.md`](docs/testing.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,12 @@
+# Testing
+
+This project uses [pytest](https://pytest.org) with the
+[pytest-copier](https://github.com/copier-org/pytest-copier) plugin to verify the
+Copier template renders correctly.
+
+Run the tests after making changes to the template:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-copier>=1.0

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime
+import subprocess
+
+import pytest
+from pytest_copier import CopierRunner
+
+TEMPLATE_PATH = Path(__file__).parents[1]
+
+
+def test_template_renders(tmp_path: Path) -> None:
+    """Template renders with default values."""
+    runner = CopierRunner(str(TEMPLATE_PATH))
+    project = runner.copy(
+        str(tmp_path),
+        data={
+            "project_name": "Example",
+            "package_name": "example",
+            "license_year": datetime.now().year,
+            "license_holder": "Example Dev",
+            "license_email": "example@example.com",
+        },
+    )
+    assert (project / "Cargo.toml").exists()
+    assert (project / "src" / "main.rs").exists()
+    subprocess.run(["cargo", "build"], cwd=project, check=True)


### PR DESCRIPTION
## Summary
- add pytest-copier unit test
- describe test usage in README and docs
- document test dependencies
- link to docs from README
- compile generated project in tests

## Testing
- `markdownlint README.md template/README.md docs/testing.md`
- `nixie README.md template/README.md docs/testing.md`
- `cargo fmt --manifest-path template/Cargo.toml -- --check` *(fails: invalid character `{` in package name)*
- `cargo clippy --manifest-path template/Cargo.toml -- -D warnings` *(fails: invalid character `{` in package name)*
- `cargo test --manifest-path template/Cargo.toml` *(fails: invalid character `{` in package name)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_copier')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytest-copier>=1.0)*

------
https://chatgpt.com/codex/tasks/task_e_684932d243b88322be318f57cce90af4