### PR TITLE
Add Makefile scaffold

### DIFF
--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt markdownlint nixie
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
 
 APP ?= {{ package_name }}
 CARGO ?= cargo
@@ -16,26 +16,27 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-	RUSTFLAGS="-D warnings" $(CARGO) test $(BUILD_JOBS)
+        RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
-target/debug/$(APP): ## Build debug binary
-	$(CARGO) build $(BUILD_JOBS) --bin $(APP)
-
-target/release/$(APP): ## Build release binary
-	$(CARGO) build $(BUILD_JOBS) --release --bin $(APP)
+target/%/$(APP): ## Build binary in debug or release mode
+        $(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 
 fmt: ## Format Rust and Markdown sources
-	$(CARGO) fmt --all
-	mdformat-all
+        $(CARGO) fmt --all
+        mdformat-all
+
+check-fmt: ## Verify formatting
+        $(CARGO) fmt --all -- --check
+        mdformat-all --check
 
 markdownlint: ## Lint Markdown files
-	find . -name '*.md' -print0 | xargs -0 $(MDLINT)
+        find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
 
 nixie: ## Validate Mermaid diagrams
-	find . -name '*.md' -print0 | xargs -0 $(NIXIE)
+        find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,0 +1,31 @@
+.PHONY: all clean test build release lint fmt markdownlint nixie
+
+build: target/debug/{{ package_name }}
+release: target/release/{{ package_name }}
+
+all: release
+
+clean:
+	cargo clean
+
+test:
+	RUSTFLAGS="-D warnings" cargo test
+
+target/debug/{{ package_name }}:
+	cargo build --bin {{ package_name }}
+
+target/release/{{ package_name }}:
+	cargo build --release --bin {{ package_name }}
+
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+fmt:
+	cargo fmt --all
+	mdformat-all
+
+markdownlint:
+	find . -name '*.md' -print0 | xargs -0 markdownlint
+
+nixie:
+	find . -name '*.md' -print0 | xargs -0 nixie

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,31 +1,42 @@
-.PHONY: all clean test build release lint fmt markdownlint nixie
+.PHONY: help all clean test build release lint fmt markdownlint nixie
 
-build: target/debug/{{ package_name }}
-release: target/release/{{ package_name }}
+APP ?= {{ package_name }}
+CARGO ?= cargo
+BUILD_JOBS ?=
+CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
+MDLINT ?= markdownlint
+NIXIE ?= nixie
 
-all: release
+build: target/debug/$(APP) ## Build debug binary
+release: target/release/$(APP) ## Build release binary
 
-clean:
-	cargo clean
+all: release ## Default target builds release binary
 
-test:
-	RUSTFLAGS="-D warnings" cargo test
+clean: ## Remove build artifacts
+	$(CARGO) clean
 
-target/debug/{{ package_name }}:
-	cargo build --bin {{ package_name }}
+test: ## Run tests with warnings treated as errors
+	RUSTFLAGS="-D warnings" $(CARGO) test $(BUILD_JOBS)
 
-target/release/{{ package_name }}:
-	cargo build --release --bin {{ package_name }}
+target/debug/$(APP): ## Build debug binary
+	$(CARGO) build $(BUILD_JOBS) --bin $(APP)
 
-lint:
-	cargo clippy --all-targets --all-features -- -D warnings
+target/release/$(APP): ## Build release binary
+	$(CARGO) build $(BUILD_JOBS) --release --bin $(APP)
 
-fmt:
-	cargo fmt --all
+lint: ## Run Clippy with warnings denied
+	$(CARGO) clippy $(CLIPPY_FLAGS)
+
+fmt: ## Format Rust and Markdown sources
+	$(CARGO) fmt --all
 	mdformat-all
 
-markdownlint:
-	find . -name '*.md' -print0 | xargs -0 markdownlint
+markdownlint: ## Lint Markdown files
+	find . -name '*.md' -print0 | xargs -0 $(MDLINT)
 
-nixie:
-	find . -name '*.md' -print0 | xargs -0 nixie
+nixie: ## Validate Mermaid diagrams
+	find . -name '*.md' -print0 | xargs -0 $(NIXIE)
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary
- add `Makefile.jinja` to the template to simplify building and testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d7692bd08322905c65f6fd917f06

## Summary by Sourcery

Add a new Makefile.jinja template to streamline building, testing, linting, formatting, and release workflows via standardized make targets

Build:
- Add template/Makefile.jinja with targets for building debug and release binaries
- Include clean, test (with warnings as errors), lint (Clippy), fmt and check-fmt (Rust and Markdown), markdownlint, and nixie diagram validation
- Provide a help target to list available make commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Makefile template to automate common Rust project tasks, including building, testing, cleaning, linting, formatting, and markdown linting.  
  - Added support for validating Mermaid diagrams within Markdown files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->