### PR TITLE
Add clippy lint settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ crate preconfigured with sensible defaults and continuous integration.
 
 1. Install Copier: `pip install copier`.
 2. Run `copier copy gh:leynos/agent-template-rust <destination>`.
-3. Fill in the prompts for project, crate and license information.
+3. Fill in the prompts for project, crate, license, and nightly toolchain date.
 4. Change into the created directory and start coding.
 
 ## What you get
 
 - **Cargo setup** using the 2024 edition and Clippy's pedantic lint level
   enabled【F:template/Cargo.toml†L1-L9】.
+- **Pinned toolchain** file specifying a configurable nightly release
+  【F:template/rust-toolchain.toml.jinja†L1-L3】.
 - **A simple entry point** that prints a greeting so the project builds
   immediately【F:template/src/main.rs†L1-L3】.
 - **GitHub workflow** for running coverage with `cargo-tarpaulin` and reporting

--- a/copier.yaml
+++ b/copier.yaml
@@ -22,3 +22,7 @@ license_email:
   type: str
   default: 'pmcintosh@df12.net'
   help: 'Email for the license holder'
+rust_nightly_date:
+  type: str
+  default: '2025-06-10'
+  help: 'Date for the Rust nightly toolchain'

--- a/template/Cargo.toml.jinja
+++ b/template/Cargo.toml.jinja
@@ -7,3 +7,35 @@ edition = "2024"
 
 [lints.clippy]
 pedantic = "warn"
+
+# 1. hygiene
+allow_attributes                    = "deny"
+allow_attributes_without_reason     = "deny"
+blanket_clippy_restriction_lints    = "deny"
+
+# 2. debugging leftovers
+dbg_macro       = "deny"
+print_stdout    = "deny"
+print_stderr    = "deny"
+
+# 3. panic-prone operations
+unwrap_used                     = "deny"
+expect_used                     = "deny"
+indexing_slicing                = "deny"
+string_slice                    = "deny"
+integer_division                = "deny"
+integer_division_remainder_used = "deny"
+
+# 4. portability
+host_endian_bytes  = "deny"
+little_endian_bytes= "deny"
+big_endian_bytes   = "deny"
+
+# 5. nursery idiom polish
+or_fun_call            = "deny"
+option_if_let_else     = "deny"
+use_self               = "deny"
+string_lit_as_bytes    = "deny"
+
+# 6. numerical foot-guns
+float_arithmetic = "deny"

--- a/template/Cargo.toml.jinja
+++ b/template/Cargo.toml.jinja
@@ -27,9 +27,9 @@ integer_division                = "deny"
 integer_division_remainder_used = "deny"
 
 # 4. portability
-host_endian_bytes  = "deny"
-little_endian_bytes= "deny"
-big_endian_bytes   = "deny"
+host_endian_bytes   = "deny"
+little_endian_bytes = "deny"
+big_endian_bytes    = "deny"
 
 # 5. nursery idiom polish
 or_fun_call            = "deny"

--- a/template/clippy.toml
+++ b/template/clippy.toml
@@ -1,0 +1,2 @@
+# Align with CodeScene’s ceiling
+cognitive-complexity-threshold = 12     # default is 25

--- a/template/rust-toolchain.toml.jinja
+++ b/template/rust-toolchain.toml.jinja
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-{{ rust_nightly_date }}"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- configure `lints.clippy` in Cargo manifest
- set `cognitive-complexity-threshold` for clippy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858404760c08322b0bcbb410d78b54c

## Summary by Sourcery

Configure clippy linting with stricter deny rules and reduce cognitive complexity threshold

Enhancements:
- Add detailed Clippy lint rules in Cargo.toml.jinja to deny hygiene, debugging leftovers, panic-prone operations, portability issues, nursery idioms, and numerical foot-guns lints
- Introduce clippy.toml with a lowered cognitive-complexity-threshold of 12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded linting rules to enforce stricter code quality and safety checks.
	- Introduced a new configuration to flag code with high cognitive complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->