### PR TITLE
Add validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository provides a [Copier](https://copier.readthedocs.io/) template for
 starting new Rust projects. Running Copier with this template generates a fresh
 crate preconfigured with sensible defaults and continuous integration.
 
+The template requires **Copier 9.0** or later to avoid incompatibilities.
+
 ## How to use
 
-1. Install Copier: `pip install copier`.
+1. Install Copier 9.0 or later: `pip install copier`.
 2. Run `copier copy gh:leynos/agent-template-rust <destination>`.
 3. Fill in the prompts for project, crate, license, and nightly toolchain date.
 4. Change into the created directory and start coding.

--- a/copier.yaml
+++ b/copier.yaml
@@ -1,4 +1,4 @@
-_min_copier_version: '7.0'
+_min_copier_version: '9.0'
 _subdirectory: template
 templates_suffix: ""
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,8 @@
 # Testing
 
 This project uses [pytest](https://pytest.org) with the
-[pytest-copier](https://github.com/copier-org/pytest-copier) plugin to verify the
-Copier template renders correctly.
+[pytest-copier](https://github.com/copier-org/pytest-copier)
+plugin to verify the Copier template renders correctly.
 
 Run the tests after making changes to the template:
 
@@ -10,3 +10,6 @@ Run the tests after making changes to the template:
 pip install -r requirements.txt
 pytest
 ```
+
+The tests build the rendered project and validate the generated Makefile with
+`mbake`. They also run `cargo clippy` so lint warnings are treated as errors.

--- a/template/Cargo.toml.jinja
+++ b/template/Cargo.toml.jinja
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 
 # 1. hygiene
 allow_attributes                    = "deny"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from datetime import datetime
-import subprocess
 
 import pytest
 from pytest_copier.plugin import CopierFixture
@@ -56,3 +55,31 @@ def test_template_renders_lib_flavour(tmp_path: Path, copier: CopierFixture) -> 
     )
     assert (project / "src" / "lib.rs").exists()
     project.run("cargo build")
+
+
+def test_makefile_validates(tmp_path: Path, copier: CopierFixture) -> None:
+    """Generated Makefile validates with mbake."""
+    project = copier.copy(
+        tmp_path,
+        project_name="MakefileExample",
+        package_name="makefile_example",
+        license_year=datetime.now().year,
+        license_holder="Makefile Dev",
+        license_email="makefile@example.com",
+    )
+    assert (project / "Makefile").exists()
+    project.run("mbake validate Makefile")
+
+
+def test_clippy_runs(tmp_path: Path, copier: CopierFixture) -> None:
+    """Generated project passes Clippy."""
+    project = copier.copy(
+        tmp_path,
+        project_name="ClippyExample",
+        package_name="clippy_example",
+        license_year=datetime.now().year,
+        license_holder="Clippy Dev",
+        license_email="clippy@example.com",
+    )
+    project.run("cargo clippy --all-targets --all-features -- -D warnings")
+

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, UTC
 
 import pytest
 from pytest_copier.plugin import CopierFixture
@@ -18,7 +18,7 @@ def test_template_renders(tmp_path: Path, copier: CopierFixture) -> None:
         tmp_path,
         project_name="Example",
         package_name="example",
-        license_year=datetime.now().year,
+        license_year=datetime.now(tz=UTC).year,
         license_holder="Example Dev",
         license_email="example@example.com",
     )
@@ -33,7 +33,7 @@ def test_template_renders_app_flavour(tmp_path: Path, copier: CopierFixture) -> 
         tmp_path,
         project_name="AppExample",
         package_name="app_example",
-        license_year=datetime.now().year,
+        license_year=datetime.now(tz=UTC).year,
         license_holder="App Dev",
         license_email="app@example.com",
         flavour=APP,
@@ -48,7 +48,7 @@ def test_template_renders_lib_flavour(tmp_path: Path, copier: CopierFixture) -> 
         tmp_path,
         project_name="LibExample",
         package_name="lib_example",
-        license_year=datetime.now().year,
+        license_year=datetime.now(tz=UTC).year,
         license_holder="Lib Dev",
         license_email="lib@example.com",
         flavour=LIB,
@@ -63,7 +63,7 @@ def test_makefile_validates(tmp_path: Path, copier: CopierFixture) -> None:
         tmp_path,
         project_name="MakefileExample",
         package_name="makefile_example",
-        license_year=datetime.now().year,
+        license_year=datetime.now(tz=UTC).year,
         license_holder="Makefile Dev",
         license_email="makefile@example.com",
     )
@@ -77,7 +77,7 @@ def test_clippy_runs(tmp_path: Path, copier: CopierFixture) -> None:
         tmp_path,
         project_name="ClippyExample",
         package_name="clippy_example",
-        license_year=datetime.now().year,
+        license_year=datetime.now(tz=UTC).year,
         license_holder="Clippy Dev",
         license_email="clippy@example.com",
     )


### PR DESCRIPTION
## Summary
- add test for `mbake validate` on generated Makefile
- add test for `cargo clippy` on generated template
- document new checks in testing guide

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: lint error from cargo clippy)*

------
https://chatgpt.com/codex/tasks/task_e_68727965f70883229e0c9e6f8b00cd50

## Summary by Sourcery

Add tests to validate the generated Makefile with mbake and enforce cargo clippy linting on the rendered project, and update the testing documentation accordingly.

Documentation:
- Update testing guide to document Makefile validation and Clippy lint checks

Tests:
- Add test for validating generated Makefile with mbake
- Add test to enforce cargo clippy linting on generated template