### PR TITLE
Skip templated dependency audit on Dependabot PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help spelling test
+.PHONY: help check-fmt fmt lint spelling typecheck test
 
 MAKEFLAGS += --no-print-directory
 
@@ -7,13 +7,27 @@ TYPOS_VERSION ?= 1.48.0
 TYPOS := uv tool run typos@$(TYPOS_VERSION)
 WITH_ACT ?= 0
 ACT_TEST_ENV = $(if $(filter 1 true yes on,$(WITH_ACT)),RUN_ACT_VALIDATION=1,)
+PYTEST_DEPS = --with pytest-copier --with pyyaml --with syrupy --with make-parser --with hypothesis
+MYPY_DEPS = $(PYTEST_DEPS) --with types-PyYAML
 
 test: ## Run template tests
 	@if [ -z "$(strip $(UV))" ]; then \
 		echo "uvx is required to run template tests. Install uv from https://docs.astral.sh/uv/getting-started/installation/" >&2; \
 		exit 1; \
 	fi
-	$(ACT_TEST_ENV) $(UV) --with pytest-copier --with pyyaml --with syrupy --with make-parser --with hypothesis pytest tests/
+	$(ACT_TEST_ENV) $(UV) $(PYTEST_DEPS) pytest tests/
+
+check-fmt: ## Verify parent Python formatting
+	$(UV) --with ruff ruff format --check tests/
+
+fmt: ## Format parent Python tests
+	$(UV) --with ruff ruff format tests/
+
+lint: ## Lint parent Python tests
+	$(UV) --with ruff ruff check tests/
+
+typecheck: ## Type-check parent Python tests
+	$(UV) --with mypy $(MYPY_DEPS) mypy tests/
 
 spelling: ## Enforce en-GB-oxendict spelling in parent and template prose
 	uv run scripts/generate_typos_config.py

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ WITH_ACT ?= 0
 ACT_TEST_ENV = $(if $(filter 1 true yes on,$(WITH_ACT)),RUN_ACT_VALIDATION=1,)
 PYTEST_DEPS = --with pytest-copier --with pyyaml --with syrupy --with make-parser --with hypothesis
 MYPY_DEPS = $(PYTEST_DEPS) --with types-PyYAML
+REQUIRE_UVX = @if [ -z "$(strip $(UV))" ]; then echo "uvx is required to run template tests. Install uv from https://docs.astral.sh/uv/getting-started/installation/" >&2; exit 1; fi
 
 test: ## Run template tests
 	@if [ -z "$(strip $(UV))" ]; then \
@@ -18,15 +19,19 @@ test: ## Run template tests
 	$(ACT_TEST_ENV) $(UV) $(PYTEST_DEPS) pytest tests/
 
 check-fmt: ## Verify parent Python formatting
+	$(REQUIRE_UVX)
 	$(UV) --with ruff ruff format --check tests/
 
 fmt: ## Format parent Python tests
+	$(REQUIRE_UVX)
 	$(UV) --with ruff ruff format tests/
 
 lint: ## Lint parent Python tests
+	$(REQUIRE_UVX)
 	$(UV) --with ruff ruff check tests/
 
 typecheck: ## Type-check parent Python tests
+	$(REQUIRE_UVX)
 	$(UV) --with mypy $(MYPY_DEPS) mypy tests/
 
 spelling: ## Enforce en-GB-oxendict spelling in parent and template prose

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -12,11 +12,10 @@ Run the public parent gate:
 make test
 ```
 
-The target uses
-`uvx --with pytest-copier --with pyyaml --with syrupy --with make-parser --with hypothesis pytest tests/`,
-so Python test dependencies must be added to that invocation before tests
-import them. Keep long runs logged through `tee` into `/tmp`, following the
-example in `AGENTS.md`.
+The target uses `uvx --with pytest-copier --with pyyaml --with syrupy --with
+make-parser --with hypothesis pytest tests/`, so Python test dependencies must
+be added to that invocation before tests import them. Keep long runs logged
+through `tee` into `/tmp`, following the example in `AGENTS.md`.
 
 The tests render both library and application projects, run generated public
 gates such as `make all`, validate generated Makefiles with `mbake`, and parse
@@ -44,6 +43,13 @@ Generated audit coverage is tested without network access by replacing Cargo
 with a fake executable. The regression verifies that `make rust-audit` derives
 the workspace root from `cargo metadata`, ignores manifests outside workspace
 metadata, and invokes `cargo audit` once from the workspace root.
+
+Generated CI skips the `cargo-audit` install, Python setup, and `make audit`
+steps when `github.actor` is `dependabot[bot]`. That keeps whole-lockfile
+advisories from blocking unrelated Dependabot PRs while leaving the audit gate
+in place for human PRs. The compensating control is
+`template/.github/workflows/audit.yml`, which runs weekly and can also be
+triggered manually.
 
 Optional GitHub Actions validation runs rendered workflows through `act`. It is
 disabled by default and only runs when `WITH_ACT=1` is present:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -21,6 +21,17 @@ The tests render both library and application projects, run generated public
 gates such as `make all`, validate generated Makefiles with `mbake`, and parse
 generated `Cargo.toml` files as TOML.
 
+## Formatting, Linting, and Type Checking
+
+The parent gates run Ruff and mypy over the `tests/` tree; install `uv` so
+`uvx` can provision the tools on demand:
+
+- `make check-fmt` verifies formatting with `ruff format --check`.
+- `make fmt` rewrites formatting with `ruff format`.
+- `make lint` runs `ruff check`.
+- `make typecheck` runs `mypy` with the pytest dependency stubs and
+  `types-PyYAML`.
+
 ## Shared Oxford Spelling Gate
 
 Both the template repository and rendered projects enforce en-GB-oxendict

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -53,7 +53,10 @@ The generated `Makefile` exposes these public targets:
 - `make release` builds the release target.
 - `make coverage` writes `lcov.info` using `cargo llvm-cov` and `lld`.
 - `make audit` derives the Rust workspace root with `cargo metadata` and runs
-  `cargo audit` once from that root.
+  `cargo audit` once from that root. Generated CI skips this gate for
+  Dependabot pull requests so whole-lockfile advisories do not block unrelated
+  dependency bumps; human pull requests still run it. A separate scheduled
+  audit workflow keeps the lockfile covered.
 - `make markdownlint` checks Markdown files and enforces en-GB-oxendict
   spelling through the pinned `typos` release.
 - `make spelling` refreshes the shared Oxford dictionary when its published

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -46,7 +46,9 @@ The generated `Makefile` exposes these public targets:
 
 - `make all` runs formatting checks, linting, tests, and spelling checks.
 - `make check-fmt` verifies Rust formatting.
+- `make fmt` formats Rust and Markdown sources.
 - `make lint` runs rustdoc, Clippy, and Whitaker with warnings denied.
+- `make typecheck` type-checks the workspace without building.
 - `make test` runs `cargo nextest run` when cargo-nextest is installed and
   falls back to `cargo test` otherwise. All projects also run doctests.
 - `make build` builds the debug target.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -55,8 +55,9 @@ The generated `Makefile` exposes these public targets:
 - `make audit` derives the Rust workspace root with `cargo metadata` and runs
   `cargo audit` once from that root. Generated CI skips this gate for
   Dependabot pull requests so whole-lockfile advisories do not block unrelated
-  dependency bumps; human pull requests still run it. A separate scheduled
-  audit workflow keeps the lockfile covered.
+  dependency bumps; human pull requests still run it. The separate
+  `.github/workflows/audit.yml` workflow runs weekly and can also be triggered
+  manually to keep the lockfile covered.
 - `make markdownlint` checks Markdown files and enforces en-GB-oxendict
   spelling through the pinned `typos` release.
 - `make spelling` refreshes the shared Oxford dictionary when its published

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@455d9ed03477c0026da96c2541ca26569a74acac
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install cargo-audit
         env:
           RUSTFLAGS: ""

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -1,0 +1,36 @@
+name: Scheduled dependency audit
+
+# CI skips `make audit` on Dependabot pull requests so that newly published
+# advisories against the existing lockfile cannot block unrelated dependency
+# bumps. This scheduled run is the compensating control: it audits the
+# default branch weekly so anything that slips through surfaces within days.
+
+'on':
+  schedule:
+    - cron: '41 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@455d9ed03477c0026da96c2541ca26569a74acac
+      - name: Install cargo-audit
+        env:
+          RUSTFLAGS: ""
+        run: cargo binstall --no-confirm cargo-audit
+      - name: Setup Python for audit manifest extraction
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.x'
+      - name: Audit dependencies
+        run: make audit

--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -49,11 +49,17 @@ jobs:
         env:
           RUSTFLAGS: ""
         run: cargo binstall --no-confirm --locked cargo-nextest
+      # Dependency audits report advisories against the whole lockfile, so a
+      # newly published advisory would fail every Dependabot PR regardless of
+      # content and deadlock auto-merge. The scheduled audit workflow covers
+      # Dependabot merges instead.
       - name: Install cargo-audit
+        if: github.actor != 'dependabot[bot]'
         env:
           RUSTFLAGS: ""
         run: cargo binstall --no-confirm cargo-audit
       - name: Setup Python for audit manifest extraction
+        if: github.actor != 'dependabot[bot]'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
@@ -82,6 +88,7 @@ jobs:
           whitaker-installer --cranelift
           echo "Whitaker binary: $(command -v whitaker || true)"
       - name: Audit dependencies
+        if: github.actor != 'dependabot[bot]'
         run: make audit
       - name: Lint
         run: make lint

--- a/template/docs/developers-guide.md.jinja
+++ b/template/docs/developers-guide.md.jinja
@@ -10,7 +10,12 @@ Use `make all` as the public entrypoint for formatting, linting, and tests.
 `cargo nextest run` and falls back to `cargo test` when cargo-nextest is not
 available. `make audit` derives the Rust workspace root with
 `cargo metadata`, logs workspace member manifests, and runs `cargo audit` once
-from the workspace root. `make coverage` uses `cargo llvm-cov` with `lld`.
+from the workspace root. PR CI skips `make audit` and the audit-only setup when
+`github.actor` is `dependabot[bot]`; that keeps whole-lockfile advisories from
+blocking unrelated Dependabot PRs while human PRs retain the audit gate. The
+compensating control is `.github/workflows/audit.yml`, which runs weekly and
+can also be triggered manually. `make coverage` uses `cargo llvm-cov` with
+`lld`.
 
 GitHub Actions Act validation lives in `.github/workflows/act-validation.yml`.
 The main `.github/workflows/ci.yml` workflow deliberately does not run

--- a/template/docs/developers-guide.md.jinja
+++ b/template/docs/developers-guide.md.jinja
@@ -8,14 +8,17 @@ This guide explains the contributor workflow for the generated
 Use `make all` as the public entrypoint for formatting, linting, and tests.
 `make lint` runs rustdoc, Clippy, and Whitaker. `make test` prefers
 `cargo nextest run` and falls back to `cargo test` when cargo-nextest is not
-available. `make audit` derives the Rust workspace root with
-`cargo metadata`, logs workspace member manifests, and runs `cargo audit` once
-from the workspace root. PR CI skips `make audit` and the audit-only setup when
-`github.actor` is `dependabot[bot]`; that keeps whole-lockfile advisories from
-blocking unrelated Dependabot PRs while human PRs retain the audit gate. The
-compensating control is `.github/workflows/audit.yml`, which runs weekly and
-can also be triggered manually. `make coverage` uses `cargo llvm-cov` with
-`lld`.
+available. `make check-fmt` verifies Rust formatting with
+`cargo fmt --all -- --check`, and `make fmt` formats Rust sources with
+nightly `rustfmt` and Markdown with `mdformat`. `make typecheck`
+type-checks without building via `cargo check`. `make audit` derives the
+Rust workspace root with `cargo metadata`, logs workspace member manifests,
+and runs `cargo audit` once from the workspace root. PR CI skips `make audit`
+and the audit-only setup when `github.actor` is `dependabot[bot]`; that keeps
+whole-lockfile advisories from blocking unrelated Dependabot PRs while human
+PRs retain the audit gate. The compensating control is
+`.github/workflows/audit.yml`, which runs weekly and can also be triggered
+manually. `make coverage` uses `cargo llvm-cov` with `lld`.
 
 GitHub Actions Act validation lives in `.github/workflows/act-validation.yml`.
 The main `.github/workflows/ci.yml` workflow deliberately does not run

--- a/template/docs/users-guide.md.jinja
+++ b/template/docs/users-guide.md.jinja
@@ -21,7 +21,9 @@ The generated `Makefile` exposes these public targets:
 
 - `make all` runs formatting checks, linting, tests, and spelling checks.
 - `make check-fmt` verifies Rust formatting.
+- `make fmt` formats Rust and Markdown sources.
 - `make lint` runs rustdoc, Clippy, and Whitaker with warnings denied.
+- `make typecheck` type-checks the workspace without building.
 - `make test` runs `cargo nextest run` when cargo-nextest is installed and
   falls back to `cargo test` otherwise. All projects also run doctests.
 - `make build` builds the debug target.

--- a/template/docs/users-guide.md.jinja
+++ b/template/docs/users-guide.md.jinja
@@ -28,7 +28,11 @@ The generated `Makefile` exposes these public targets:
 - `make release` builds the release target.
 - `make coverage` writes `lcov.info` using `cargo llvm-cov` and `lld`.
 - `make audit` derives the Rust workspace root with `cargo metadata` and runs
-  `cargo audit` once from that root.
+  `cargo audit` once from that root. In PR CI, Dependabot runs skip `make
+  audit` and the audit-only setup when `github.actor` is `dependabot[bot]`, so
+  whole-lockfile advisories do not block unrelated dependency updates. Human PRs
+  still retain the audit gate, and `.github/workflows/audit.yml` runs weekly and
+  can also be triggered manually as the compensating control.
 - `make markdownlint` checks Markdown files and enforces en-GB-oxendict
   spelling through the pinned `typos` release.
 - `make spelling` refreshes the shared Oxford dictionary when its published

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,3 @@ rendered-file parsers, generated-project command helpers, workflow contract
 assertions, container runtime environment helpers, and pytest fixtures for
 ``pytest-copier``.
 """
-

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -5,4 +5,3 @@ generated file parsing, rendering helpers, and generated tooling contract
 assertions. Fixtures remain in :mod:`tests.conftest`, while container-aware
 runtime helpers remain in :mod:`tests.utilities`.
 """
-

--- a/tests/helpers/tooling_contracts/cargo.py
+++ b/tests/helpers/tooling_contracts/cargo.py
@@ -11,9 +11,9 @@ def _assert_cargo_package_contracts(
     package: dict[str, Any], metadata: dict[str, Any], flavour: str
 ) -> None:
     """Assert generated Cargo package metadata contracts."""
-    assert package.get("description") == "ToolingExample package used by template tests.", (
-        "expected generated Cargo.toml to include package description"
-    )
+    assert (
+        package.get("description") == "ToolingExample package used by template tests."
+    ), "expected generated Cargo.toml to include package description"
     assert package.get("repository") == "https://github.com/example/tooling_example", (
         "expected generated Cargo.toml to include repository URL"
     )
@@ -63,7 +63,7 @@ def _assert_cargo_config_contracts(
         assert f"[target.{dev_target}]" in cargo_config, (
             "expected generated cargo config to include Linux target settings"
         )
-        assert 'link-arg=-fuse-ld=mold' in cargo_config, (
+        assert "link-arg=-fuse-ld=mold" in cargo_config, (
             "expected generated cargo config to use mold linker for Linux"
         )
     else:
@@ -71,7 +71,7 @@ def _assert_cargo_config_contracts(
             "expected generated cargo config to avoid mold target blocks "
             "for non-Linux targets"
         )
-        assert 'link-arg=-fuse-ld=mold' not in cargo_config, (
+        assert "link-arg=-fuse-ld=mold" not in cargo_config, (
             "expected generated cargo config to avoid mold for non-Linux targets"
         )
 

--- a/tests/helpers/tooling_contracts/makefile.py
+++ b/tests/helpers/tooling_contracts/makefile.py
@@ -121,7 +121,7 @@ def _load_and_parse_makefile_rules(makefile: str) -> dict[str, list[str]]:
     }
 
     def normalise_target(match: re.Match[str]) -> str:
-        target = cast(str, match.group(1))
+        target = cast("str", match.group(1))
         return normalised_targets.get(target, target) + ":"
 
     normalised_makefile = re.sub(
@@ -133,7 +133,7 @@ def _load_and_parse_makefile_rules(makefile: str) -> dict[str, list[str]]:
     with tempfile.TemporaryDirectory() as tmp_dir:
         makefile_path = Path(tmp_dir) / "Makefile"
         makefile_path.write_text(normalised_makefile, encoding="utf-8")
-        make_load = getattr(import_module("make_parser"), "make_load")
+        make_load = import_module("make_parser").make_load
         parsed = cast("dict[str, Any]", make_load(makefile_path))
     normalised_rules = cast("dict[str, dict[str, list[str]]]", parsed["rules"])
     return {

--- a/tests/helpers/tooling_contracts/makefile.py
+++ b/tests/helpers/tooling_contracts/makefile.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import re
 import tempfile
+from importlib import import_module
 from pathlib import Path
-
-import make_parser
+from typing import Any, cast
 
 
 def _assert_makefile_contracts(makefile: str) -> None:
@@ -121,7 +121,7 @@ def _load_and_parse_makefile_rules(makefile: str) -> dict[str, list[str]]:
     }
 
     def normalise_target(match: re.Match[str]) -> str:
-        target = match.group(1)
+        target = cast(str, match.group(1))
         return normalised_targets.get(target, target) + ":"
 
     normalised_makefile = re.sub(
@@ -133,8 +133,9 @@ def _load_and_parse_makefile_rules(makefile: str) -> dict[str, list[str]]:
     with tempfile.TemporaryDirectory() as tmp_dir:
         makefile_path = Path(tmp_dir) / "Makefile"
         makefile_path.write_text(normalised_makefile, encoding="utf-8")
-        parsed = make_parser.make_load(makefile_path)
-    normalised_rules = parsed["rules"]
+        make_load = getattr(import_module("make_parser"), "make_load")
+        parsed = cast("dict[str, Any]", make_load(makefile_path))
+    normalised_rules = cast("dict[str, dict[str, list[str]]]", parsed["rules"])
     return {
         target: normalised_rules[normalised_targets.get(target, target)]["commands"]
         for target in target_names

--- a/tests/helpers/tooling_contracts/orchestration.py
+++ b/tests/helpers/tooling_contracts/orchestration.py
@@ -13,6 +13,7 @@ from tests.helpers.tooling_contracts.documentation import (
 )
 from tests.helpers.tooling_contracts.makefile import _assert_makefile_contracts
 from tests.helpers.tooling_contracts.workflows import (
+    _assert_audit_workflow_contracts,
     _assert_ci_workflow_contracts,
     _assert_release_workflow_contracts,
 )
@@ -29,6 +30,7 @@ def assert_generated_tooling_contracts(
     rust_toolchain: str,
     parsed_ci_workflow: dict[str, Any],
     ci_workflow: str,
+    audit_workflow: str,
     act_workflow: str,
     docs_contents: str,
     repository_layout: str,
@@ -58,6 +60,8 @@ def assert_generated_tooling_contracts(
         Parsed generated CI workflow mapping.
     ci_workflow
         Rendered generated CI workflow text.
+    audit_workflow
+        Rendered generated scheduled dependency audit workflow text.
     act_workflow
         Rendered generated act-validation workflow text.
     docs_contents
@@ -94,6 +98,7 @@ def assert_generated_tooling_contracts(
     _assert_ci_workflow_contracts(
         parsed_ci_workflow, ci_workflow, act_workflow, test_stub
     )
+    _assert_audit_workflow_contracts(audit_workflow)
     assert_documentation_navigation_contracts(docs_contents, repository_layout, flavour)
     assert "[Documentation contents](docs/contents.md)" in readme, (
         "expected generated README to link to the documentation contents"

--- a/tests/helpers/tooling_contracts/orchestration.py
+++ b/tests/helpers/tooling_contracts/orchestration.py
@@ -94,9 +94,7 @@ def assert_generated_tooling_contracts(
     _assert_ci_workflow_contracts(
         parsed_ci_workflow, ci_workflow, act_workflow, test_stub
     )
-    assert_documentation_navigation_contracts(
-        docs_contents, repository_layout, flavour
-    )
+    assert_documentation_navigation_contracts(docs_contents, repository_layout, flavour)
     assert "[Documentation contents](docs/contents.md)" in readme, (
         "expected generated README to link to the documentation contents"
     )

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -33,6 +33,25 @@ def _is_pinned_action(uses: str, action_path: str) -> bool:
     return re.fullmatch(rf"{re.escape(action_path)}@[0-9a-f]{{40}}", uses) is not None
 
 
+def _step_mappings(steps: list[Any]) -> list[dict[str, Any]]:
+    """Return only the mapping-shaped entries from a workflow steps sequence."""
+    mappings: list[dict[str, Any]] = []
+    for step in steps:
+        match step:
+            case dict() as mapping:
+                mappings.append(mapping)
+    return mappings
+
+
+def _disables_credential_persistence(step: dict[str, Any]) -> bool:
+    """Return whether ``step`` checks out sources without persisting credentials."""
+    match step.get("with"):
+        case {"persist-credentials": False}:
+            return True
+        case _:
+            return False
+
+
 def assert_ci_coverage_action_contract(ci_workflow: str) -> None:
     """Assert generated CI coverage inputs used by act validation.
 
@@ -126,6 +145,7 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         "expected generated audit job to have a bounded runtime"
     )
     steps = require_sequence(audit, "steps", "audit workflow job")
+    step_mappings = _step_mappings(steps)
     checkout_path = "actions/checkout"
     expected_steps = {
         None: checkout_path,
@@ -134,9 +154,8 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
     for step_name, action_path in expected_steps.items():
         matching_steps = [
             step
-            for step in steps
-            if isinstance(step, dict)
-            and step.get("name") == step_name
+            for step in step_mappings
+            if step.get("name") == step_name
             and _is_pinned_action(str(step.get("uses", "")), action_path)
         ]
         assert len(matching_steps) == 1, (
@@ -145,20 +164,15 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         )
     checkout_steps = [
         step
-        for step in steps
-        if isinstance(step, dict)
-        and _is_pinned_action(str(step.get("uses", "")), checkout_path)
+        for step in step_mappings
+        if _is_pinned_action(str(step.get("uses", "")), checkout_path)
     ]
     assert checkout_steps, "expected generated audit workflow checkout step"
-    assert all(
-        isinstance(step.get("with"), dict)
-        and step["with"].get("persist-credentials") is False
-        for step in checkout_steps
-    ), "expected generated audit workflow checkout to disable credential persistence"
+    assert all(_disables_credential_persistence(step) for step in checkout_steps), (
+        "expected generated audit workflow checkout to disable credential persistence"
+    )
     setup_rust_steps = [
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Setup Rust"
+        step for step in step_mappings if step.get("name") == "Setup Rust"
     ]
     assert len(setup_rust_steps) == 1, (
         "expected generated audit workflow to include one Setup Rust step"
@@ -169,16 +183,13 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         f"40-hex commit SHA, got {setup_rust_uses!r}"
     )
     assert any(
-        isinstance(step, dict)
-        and step.get("name") == "Install cargo-audit"
+        step.get("name") == "Install cargo-audit"
         and step.get("run") == "cargo binstall --no-confirm cargo-audit"
-        for step in steps
+        for step in step_mappings
     ), "expected generated audit workflow to install cargo-audit"
     assert any(
-        isinstance(step, dict)
-        and step.get("name") == "Audit dependencies"
-        and step.get("run") == "make audit"
-        for step in steps
+        step.get("name") == "Audit dependencies" and step.get("run") == "make audit"
+        for step in step_mappings
     ), "expected generated audit workflow to run make audit"
 
 
@@ -306,8 +317,8 @@ def _assert_ci_workflow_contracts(
     dependabot_guard = "github.actor != 'dependabot[bot]'"
     dependabot_guarded_steps = [
         step.get("name")
-        for step in steps
-        if isinstance(step, dict) and step.get("if") == dependabot_guard
+        for step in _step_mappings(steps)
+        if step.get("if") == dependabot_guard
     ]
     assert dependabot_guarded_steps == [
         "Install cargo-audit",

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -143,7 +143,8 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         for step in steps
         if isinstance(step, dict) and step.get("uses") == checkout_action
     ]
-    assert checkout_steps and all(
+    assert checkout_steps, "expected generated audit workflow checkout step"
+    assert all(
         isinstance(step.get("with"), dict)
         and step["with"].get("persist-credentials") is False
         for step in checkout_steps

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -321,13 +321,13 @@ def _assert_ci_workflow_contracts(
         "Audit dependencies",
     ]
     audit_steps = [
-        step for step in _step_mappings(steps) if step.get("name") in audit_step_names
+        (step.get("name"), step.get("if"))
+        for step in _step_mappings(steps)
+        if step.get("name") in audit_step_names
     ]
-    assert [step.get("name") for step in audit_steps] == audit_step_names, (
-        "expected exactly one of each audit-specific CI step"
-    )
-    assert all(step.get("if") == dependabot_guard for step in audit_steps), (
-        "expected only audit-specific CI steps to skip Dependabot pull requests"
+    assert audit_steps == [(name, dependabot_guard) for name in audit_step_names], (
+        "expected each audit-specific CI step exactly once, in order, and guarded "
+        "against Dependabot pull requests"
     )
     rust_tool_install_step_names = [
         "Install test runner",

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -90,6 +90,70 @@ def assert_ci_coverage_action_contract(ci_workflow: str) -> None:
         "expected CI coverage step to enable the coverage ratchet"
     )
 
+def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
+    """Assert generated scheduled dependency audit workflow contracts."""
+    parsed_audit_workflow = parse_yaml_mapping(audit_workflow, "audit workflow")
+    triggers = require_mapping(parsed_audit_workflow, "on", "audit workflow")
+    schedule = require_sequence(triggers, "schedule", "audit workflow triggers")
+    assert schedule == [{"cron": "41 6 * * 1"}], (
+        "expected generated audit workflow to run weekly"
+    )
+    assert "workflow_dispatch" in triggers, (
+        "expected generated audit workflow to support manual runs"
+    )
+
+    jobs = require_mapping(parsed_audit_workflow, "jobs", "audit workflow")
+    audit = require_mapping(jobs, "audit", "audit workflow jobs")
+    assert audit.get("runs-on") == "ubuntu-latest", (
+        "expected generated audit job to use Ubuntu"
+    )
+    assert audit.get("timeout-minutes") == 30, (
+        "expected generated audit job to have a bounded runtime"
+    )
+    steps = require_sequence(audit, "steps", "audit workflow job")
+    expected_steps = {
+        None: "actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231",
+        "Setup Python for audit manifest extraction": (
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
+        ),
+    }
+    for step_name, action in expected_steps.items():
+        matching_steps = [
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("name") == step_name
+            and step.get("uses") == action
+        ]
+        assert len(matching_steps) == 1, (
+            f"expected generated audit workflow to include pinned {action}"
+        )
+    setup_rust_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Setup Rust"
+    ]
+    assert len(setup_rust_steps) == 1, (
+        "expected generated audit workflow to include one Setup Rust step"
+    )
+    setup_rust_uses = str(setup_rust_steps[0].get("uses", ""))
+    assert _SETUP_RUST_USES_TEXT_RE.fullmatch(setup_rust_uses), (
+        "expected generated audit workflow to use setup-rust pinned to a full "
+        f"40-hex commit SHA, got {setup_rust_uses!r}"
+    )
+    assert any(
+        isinstance(step, dict)
+        and step.get("name") == "Install cargo-audit"
+        and step.get("run") == "cargo binstall --no-confirm cargo-audit"
+        for step in steps
+    ), "expected generated audit workflow to install cargo-audit"
+    assert any(
+        isinstance(step, dict)
+        and step.get("name") == "Audit dependencies"
+        and step.get("run") == "make audit"
+        for step in steps
+    ), "expected generated audit workflow to run make audit"
+
 
 def assert_coverage_main_workflow_contract(coverage_main_workflow: str) -> None:
     """Assert the generated ``coverage-main.yml`` push-and-upload contract.
@@ -212,6 +276,17 @@ def _assert_ci_workflow_contracts(
     ), "expected generated CI checkout steps to disable credential persistence"
     build_test = require_mapping(jobs, "build-test", "CI workflow jobs")
     steps = require_sequence(build_test, "steps", "CI build-test job")
+    dependabot_guard = "github.actor != 'dependabot[bot]'"
+    dependabot_guarded_steps = [
+        step.get("name")
+        for step in steps
+        if isinstance(step, dict) and step.get("if") == dependabot_guard
+    ]
+    assert dependabot_guarded_steps == [
+        "Install cargo-audit",
+        "Setup Python for audit manifest extraction",
+        "Audit dependencies",
+    ], "expected only audit-specific CI steps to skip Dependabot pull requests"
     rust_tool_install_step_names = [
         "Install test runner",
         "Install cargo-audit",

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -315,16 +315,20 @@ def _assert_ci_workflow_contracts(
     build_test = require_mapping(jobs, "build-test", "CI workflow jobs")
     steps = require_sequence(build_test, "steps", "CI build-test job")
     dependabot_guard = "github.actor != 'dependabot[bot]'"
-    dependabot_guarded_steps = [
-        step.get("name")
-        for step in _step_mappings(steps)
-        if step.get("if") == dependabot_guard
-    ]
-    assert dependabot_guarded_steps == [
+    audit_step_names = [
         "Install cargo-audit",
         "Setup Python for audit manifest extraction",
         "Audit dependencies",
-    ], "expected only audit-specific CI steps to skip Dependabot pull requests"
+    ]
+    audit_steps = [
+        step for step in _step_mappings(steps) if step.get("name") in audit_step_names
+    ]
+    assert [step.get("name") for step in audit_steps] == audit_step_names, (
+        "expected exactly one of each audit-specific CI step"
+    )
+    assert all(step.get("if") == dependabot_guard for step in audit_steps), (
+        "expected only audit-specific CI steps to skip Dependabot pull requests"
+    )
     rust_tool_install_step_names = [
         "Install test runner",
         "Install cargo-audit",

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -28,6 +28,16 @@ _SETUP_RUST_USES_TEXT_RE = re.compile(
 )
 
 
+def _is_pinned_action(uses: str, action_path: str) -> bool:
+    """Return whether ``uses`` pins ``action_path`` to a full 40-hex commit SHA.
+
+    Matching by shape rather than exact SHA keeps these contracts stable across
+    routine Dependabot bump pull requests while still enforcing that the action
+    is pinned to an immutable commit.
+    """
+    return re.fullmatch(rf"{re.escape(action_path)}@[0-9a-f]{{40}}", uses) is not None
+
+
 def assert_ci_coverage_action_contract(ci_workflow: str) -> None:
     """Assert generated CI coverage inputs used by act validation.
 
@@ -95,19 +105,20 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
     """Assert generated scheduled dependency audit workflow contracts."""
     parsed_audit_workflow = parse_yaml_mapping(audit_workflow, "audit workflow")
     triggers = require_mapping(parsed_audit_workflow, "on", "audit workflow")
+    assert set(triggers) == {"schedule", "workflow_dispatch"}, (
+        "expected generated audit workflow to trigger only on schedule and "
+        "workflow_dispatch"
+    )
     schedule = require_sequence(triggers, "schedule", "audit workflow triggers")
     assert schedule == [{"cron": "41 6 * * 1"}], (
         "expected generated audit workflow to run weekly"
-    )
-    assert "workflow_dispatch" in triggers, (
-        "expected generated audit workflow to support manual runs"
     )
 
     permissions = require_mapping(
         parsed_audit_workflow, "permissions", "audit workflow"
     )
-    assert permissions.get("contents") == "read", (
-        "expected generated audit workflow to grant least-privilege "
+    assert permissions == {"contents": "read"}, (
+        "expected generated audit workflow to grant exactly least-privilege "
         "contents: read permissions"
     )
 
@@ -120,28 +131,28 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         "expected generated audit job to have a bounded runtime"
     )
     steps = require_sequence(audit, "steps", "audit workflow job")
-    checkout_action = "actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231"
+    checkout_path = "actions/checkout"
     expected_steps = {
-        None: checkout_action,
-        "Setup Python for audit manifest extraction": (
-            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
-        ),
+        None: checkout_path,
+        "Setup Python for audit manifest extraction": "actions/setup-python",
     }
-    for step_name, action in expected_steps.items():
+    for step_name, action_path in expected_steps.items():
         matching_steps = [
             step
             for step in steps
             if isinstance(step, dict)
             and step.get("name") == step_name
-            and step.get("uses") == action
+            and _is_pinned_action(str(step.get("uses", "")), action_path)
         ]
         assert len(matching_steps) == 1, (
-            f"expected generated audit workflow to include pinned {action}"
+            f"expected generated audit workflow to include {action_path} "
+            "pinned to a full 40-hex commit SHA"
         )
     checkout_steps = [
         step
         for step in steps
-        if isinstance(step, dict) and step.get("uses") == checkout_action
+        if isinstance(step, dict)
+        and _is_pinned_action(str(step.get("uses", "")), checkout_path)
     ]
     assert checkout_steps, "expected generated audit workflow checkout step"
     assert all(

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -103,6 +103,14 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         "expected generated audit workflow to support manual runs"
     )
 
+    permissions = require_mapping(
+        parsed_audit_workflow, "permissions", "audit workflow"
+    )
+    assert permissions.get("contents") == "read", (
+        "expected generated audit workflow to grant least-privilege "
+        "contents: read permissions"
+    )
+
     jobs = require_mapping(parsed_audit_workflow, "jobs", "audit workflow")
     audit = require_mapping(jobs, "audit", "audit workflow jobs")
     assert audit.get("runs-on") == "ubuntu-latest", (
@@ -112,8 +120,9 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         "expected generated audit job to have a bounded runtime"
     )
     steps = require_sequence(audit, "steps", "audit workflow job")
+    checkout_action = "actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231"
     expected_steps = {
-        None: "actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231",
+        None: checkout_action,
         "Setup Python for audit manifest extraction": (
             "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
         ),
@@ -129,6 +138,16 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
         assert len(matching_steps) == 1, (
             f"expected generated audit workflow to include pinned {action}"
         )
+    checkout_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == checkout_action
+    ]
+    assert checkout_steps and all(
+        isinstance(step.get("with"), dict)
+        and step["with"].get("persist-credentials") is False
+        for step in checkout_steps
+    ), "expected generated audit workflow checkout to disable credential persistence"
     setup_rust_steps = [
         step
         for step in steps

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -29,12 +29,7 @@ _SETUP_RUST_USES_TEXT_RE = re.compile(
 
 
 def _is_pinned_action(uses: str, action_path: str) -> bool:
-    """Return whether ``uses`` pins ``action_path`` to a full 40-hex commit SHA.
-
-    Matching by shape rather than exact SHA keeps these contracts stable across
-    routine Dependabot bump pull requests while still enforcing that the action
-    is pinned to an immutable commit.
-    """
+    """Return whether ``uses`` pins ``action_path`` to a full 40-hex commit SHA."""
     return re.fullmatch(rf"{re.escape(action_path)}@[0-9a-f]{{40}}", uses) is not None
 
 

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -148,7 +148,6 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
     step_mappings = _step_mappings(steps)
     checkout_path = "actions/checkout"
     expected_steps = {
-        None: checkout_path,
         "Setup Python for audit manifest extraction": "actions/setup-python",
     }
     for step_name, action_path in expected_steps.items():

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -90,6 +90,7 @@ def assert_ci_coverage_action_contract(ci_workflow: str) -> None:
         "expected CI coverage step to enable the coverage ratchet"
     )
 
+
 def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
     """Assert generated scheduled dependency audit workflow contracts."""
     parsed_audit_workflow = parse_yaml_mapping(audit_workflow, "audit workflow")

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -165,9 +165,15 @@ def _assert_audit_workflow_contracts(audit_workflow: str) -> None:
     checkout_steps = [
         step
         for step in step_mappings
-        if _is_pinned_action(str(step.get("uses", "")), checkout_path)
+        if str(step.get("uses", "")).startswith(f"{checkout_path}@")
     ]
-    assert checkout_steps, "expected generated audit workflow checkout step"
+    assert len(checkout_steps) == 1, (
+        "expected generated audit workflow to include exactly one checkout step"
+    )
+    assert _is_pinned_action(str(checkout_steps[0].get("uses", "")), checkout_path), (
+        "expected generated audit workflow checkout to be pinned to a full "
+        "40-hex commit SHA"
+    )
     assert all(_disables_credential_persistence(step) for step in checkout_steps), (
         "expected generated audit workflow checkout to disable credential persistence"
     )

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -181,9 +181,7 @@ def _assert_ci_workflow_contracts(
     )
 
     parsed_act_workflow = parse_yaml_mapping(act_workflow, "act-validation workflow")
-    act_jobs = require_mapping(
-        parsed_act_workflow, "jobs", "act-validation workflow"
-    )
+    act_jobs = require_mapping(parsed_act_workflow, "jobs", "act-validation workflow")
     act_validation = require_mapping(
         act_jobs, "act-validation", "act-validation workflow jobs"
     )
@@ -228,9 +226,7 @@ def _assert_ci_workflow_contracts(
         assert len(matching_steps) == 1, (
             f"expected generated CI to include one {step_name} step"
         )
-        rust_tool_env = require_mapping(
-            matching_steps[0], "env", f"{step_name} step"
-        )
+        rust_tool_env = require_mapping(matching_steps[0], "env", f"{step_name} step")
         assert rust_tool_env.get("RUSTFLAGS") == "", (
             f"expected generated CI {step_name} step to clear inherited RUSTFLAGS"
         )
@@ -352,7 +348,7 @@ def _assert_release_workflow_contracts(release_workflow: str) -> None:
     assert "aarch64-pc-windows-gnullvm" not in release_workflow, (
         "expected app release workflow to omit unsupported cross targets"
     )
-    assert 'key: cross-${{ env.CROSS_REVISION }}' in release_workflow, (
+    assert "key: cross-${{ env.CROSS_REVISION }}" in release_workflow, (
         "expected app release workflow to cache cross by revision"
     )
     assert "files: |" in release_workflow, (

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -35,8 +35,10 @@ json_value = st.recursive(
     | st.integers()
     | st.floats(allow_nan=False, allow_infinity=False)
     | st.text(),
-    lambda children: st.lists(children, max_size=4)
-    | st.dictionaries(st.text(), children, max_size=4),
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(st.text(), children, max_size=4)
+    ),
     max_leaves=12,
 )
 
@@ -216,8 +218,7 @@ def test_ci_coverage_action_contract_validates_edges() -> None:
             _ci_workflow(
                 persist_credentials="false",
                 coverage_inputs=(
-                    "          output-path: lcov.info\n"
-                    "          format: cobertura\n"
+                    "          output-path: lcov.info\n          format: cobertura\n"
                 ),
             )
         )
@@ -264,9 +265,10 @@ def test_resolved_socket_from_docker_host_accepts_allowed_unix_path(
     allowed_dir.mkdir()
     socket_path = allowed_dir / "docker.sock"
 
-    assert _resolved_socket_from_docker_host(
-        f"unix://{socket_path}", (allowed_dir,)
-    ) == socket_path
+    assert (
+        _resolved_socket_from_docker_host(f"unix://{socket_path}", (allowed_dir,))
+        == socket_path
+    )
 
 
 def test_docker_environment_preserves_valid_unix_socket(
@@ -278,9 +280,7 @@ def test_docker_environment_preserves_valid_unix_socket(
     socket_path = allowed_dir / "docker.sock"
     docker_host = f"unix://{socket_path}"
     monkeypatch.setenv("DOCKER_HOST", docker_host)
-    monkeypatch.setattr(
-        utilities, "local_socket_dirs", lambda: (allowed_dir,)
-    )
+    monkeypatch.setattr(utilities, "local_socket_dirs", lambda: (allowed_dir,))
 
     assert docker_environment()["DOCKER_HOST"] == docker_host
 
@@ -296,9 +296,7 @@ def test_docker_environment_removes_credentials(
     monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret-key")
     monkeypatch.setenv("SOME_API_KEY", "api-key")
-    monkeypatch.setattr(
-        utilities, "local_socket_dirs", lambda: (allowed_dir,)
-    )
+    monkeypatch.setattr(utilities, "local_socket_dirs", lambda: (allowed_dir,))
 
     env = docker_environment()
 
@@ -371,9 +369,7 @@ def test_container_daemon_socket_uses_valid_docker_host(
     runtime_dir.mkdir()
     socket_path = runtime_dir / "docker.sock"
     monkeypatch.setenv("DOCKER_HOST", f"unix://{socket_path}")
-    monkeypatch.setattr(
-        utilities, "user_runtime_socket_dirs", lambda: (runtime_dir,)
-    )
+    monkeypatch.setattr(utilities, "user_runtime_socket_dirs", lambda: (runtime_dir,))
 
     assert container_daemon_socket() == f"unix://{socket_path}"
 
@@ -396,8 +392,8 @@ def test_parent_makefile_test_target_contract() -> None:
     """Validate the parent repository ``test`` target command contract."""
     makefile = Path("Makefile").read_text(encoding="utf-8")
 
-    assert ".PHONY: help spelling test" in makefile, (
-        "expected parent Makefile to mark help, spelling, and test as phony targets"
+    assert ".PHONY: help check-fmt fmt lint spelling typecheck test" in makefile, (
+        "expected parent Makefile to mark all public gate targets phony"
     )
     assert "UV := $(shell command -v uvx 2>/dev/null)" in makefile, (
         "expected parent Makefile to resolve uvx before running tests"
@@ -417,12 +413,18 @@ def test_parent_makefile_test_target_contract() -> None:
     assert "$(error uvx is required" not in makefile, (
         "expected parent Makefile not to fail at parse time when uvx is missing"
     )
-    assert (
-        "$(UV) --with pytest-copier --with pyyaml --with syrupy --with make-parser "
-        "--with hypothesis pytest tests/"
-    ) in makefile, (
+    assert ("$(ACT_TEST_ENV) $(UV) $(PYTEST_DEPS) pytest tests/") in makefile, (
         "expected parent Makefile test target to run pytest through $(UV) with "
-        "pytest-copier, pyyaml, syrupy, make-parser, and hypothesis"
+        "the shared pytest dependency list"
+    )
+    assert "$(UV) --with ruff ruff format --check tests/" in makefile, (
+        "expected parent Makefile check-fmt target to run ruff format checks"
+    )
+    assert "$(UV) --with ruff ruff check tests/" in makefile, (
+        "expected parent Makefile lint target to run ruff lint checks"
+    )
+    assert "$(UV) --with mypy $(MYPY_DEPS) mypy tests/" in makefile, (
+        "expected parent Makefile typecheck target to run mypy"
     )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -173,17 +173,31 @@ _full_shas = st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40)
 def _non_sha_refs(draw: st.DrawFn) -> str:
     """Draw refs that are never a 40-character lowercase-hex commit SHA."""
     kind = draw(st.sampled_from(("short", "long", "uppercased", "branch")))
-    if kind == "short":
-        size = draw(st.integers(min_value=0, max_value=39))
-        return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
-    if kind == "long":
-        size = draw(st.integers(min_value=41, max_value=64))
-        return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
-    if kind == "uppercased":
-        hexes = draw(st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40))
-        position = draw(st.integers(min_value=0, max_value=39))
-        return f"{hexes[:position]}G{hexes[position + 1 :]}"
-    return draw(st.sampled_from(("main", "master", "rolling", "HEAD", "v1.2.3")))
+    match kind:
+        case "short":
+            size = draw(st.integers(min_value=0, max_value=39))
+            return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
+        case "long":
+            size = draw(st.integers(min_value=41, max_value=64))
+            return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
+        case "uppercased":
+            hexes = draw(st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40))
+            position = draw(st.integers(min_value=0, max_value=39))
+            existing = hexes[position]
+            # Uppercasing a hex digit is a no-op, so fall back to a hex letter
+            # to keep the ref out of the lowercase-hex SHA shape.
+            flipped = (
+                existing.upper()
+                if existing.isalpha()
+                else draw(st.sampled_from("ABCDEF"))
+            )
+            return f"{hexes[:position]}{flipped}{hexes[position + 1 :]}"
+        case "branch":
+            return draw(
+                st.sampled_from(("main", "master", "rolling", "HEAD", "v1.2.3"))
+            )
+        case _:  # pragma: no cover - kind is drawn from the sampled set above
+            raise AssertionError(f"unexpected ref kind: {kind}")
 
 
 @given(path=_action_paths, sha=_full_shas)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,6 +21,11 @@ from tests.helpers.generated_files import (
 )
 from tests.helpers.rendering import read_generated_file
 from tests.helpers.tooling_contracts import assert_ci_coverage_action_contract
+from tests.helpers.tooling_contracts.workflows import (
+    _disables_credential_persistence,
+    _is_pinned_action,
+    _step_mappings,
+)
 from tests.test_github_actions_integration import xfail_known_act_runtime_limitations
 from tests.utilities import (
     _resolved_socket_from_docker_host,
@@ -153,6 +158,100 @@ def test_require_sequence_property(key: str, value: object) -> None:
     else:
         with pytest.raises(pytest.fail.Exception):
             require_sequence(mapping, key, "generated schema")
+
+
+_HEX_ALPHABET = "0123456789abcdef"
+_action_paths = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-._",
+    min_size=1,
+    max_size=30,
+)
+_full_shas = st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40)
+
+
+@st.composite
+def _non_sha_refs(draw: st.DrawFn) -> str:
+    """Draw refs that are never a 40-character lowercase-hex commit SHA."""
+    kind = draw(st.sampled_from(("short", "long", "uppercased", "branch")))
+    if kind == "short":
+        size = draw(st.integers(min_value=0, max_value=39))
+        return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
+    if kind == "long":
+        size = draw(st.integers(min_value=41, max_value=64))
+        return draw(st.text(alphabet=_HEX_ALPHABET, min_size=size, max_size=size))
+    if kind == "uppercased":
+        hexes = draw(st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40))
+        position = draw(st.integers(min_value=0, max_value=39))
+        return f"{hexes[:position]}G{hexes[position + 1 :]}"
+    return draw(st.sampled_from(("main", "master", "rolling", "HEAD", "v1.2.3")))
+
+
+@given(path=_action_paths, sha=_full_shas)
+def test_is_pinned_action_accepts_full_sha(path: str, sha: str) -> None:
+    """A path pinned to a 40-hex SHA matches only that exact action path."""
+    assert _is_pinned_action(f"{path}@{sha}", path)
+    assert not _is_pinned_action(f"{path}@{sha}", f"{path}-other")
+
+
+@given(path=_action_paths, ref=_non_sha_refs())
+def test_is_pinned_action_rejects_non_sha_refs(path: str, ref: str) -> None:
+    """Refs that are not a full 40-hex commit SHA are never treated as pinned."""
+    assert not _is_pinned_action(f"{path}@{ref}", path)
+
+
+_json_steps = st.lists(
+    st.one_of(
+        st.none(),
+        st.booleans(),
+        st.integers(),
+        st.text(),
+        st.lists(json_value, max_size=3),
+        st.dictionaries(st.text(max_size=5), json_value, max_size=3),
+    ),
+    max_size=6,
+)
+
+
+@given(steps=_json_steps)
+def test_step_mappings_keeps_only_mappings_in_order(steps: list[object]) -> None:
+    """``_step_mappings`` returns exactly the mapping entries, in original order."""
+    result = _step_mappings(steps)
+
+    assert result == [step for step in steps if isinstance(step, dict)]
+    assert all(isinstance(step, dict) for step in result)
+
+
+_persist_credential_values = st.sampled_from([True, False, None, 0, 1, "false", "true"])
+_with_blocks = st.one_of(
+    st.none(),
+    st.text(),
+    st.integers(),
+    st.dictionaries(st.text(min_size=1, max_size=5), json_value, max_size=3),
+    st.builds(
+        lambda base, value: {**base, "persist-credentials": value},
+        st.dictionaries(st.text(min_size=1, max_size=5), json_value, max_size=2),
+        _persist_credential_values,
+    ),
+)
+
+
+@st.composite
+def _checkout_like_steps(draw: st.DrawFn) -> dict[str, object]:
+    """Draw checkout-like steps with and without a ``with`` block."""
+    if draw(st.booleans()):
+        return {"with": draw(_with_blocks)}
+    return {}
+
+
+@given(step=_checkout_like_steps())
+def test_disables_credential_persistence_matches_spec(step: dict[str, object]) -> None:
+    """Only a ``with`` mapping whose persist-credentials is exactly False qualifies."""
+    with_block = step.get("with")
+    expected = (
+        isinstance(with_block, dict) and with_block.get("persist-credentials") is False
+    )
+
+    assert _disables_credential_persistence(step) is expected
 
 
 def test_read_generated_file_uses_shared_error_contract(tmp_path: Path) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -232,13 +232,20 @@ def test_step_mappings_keeps_only_mappings_in_order(steps: list[object]) -> None
 
 
 _persist_credential_values = st.sampled_from([True, False, None, 0, 1, "false", "true"])
+
+
+def _with_persist_credentials(base: dict[str, Any], value: object) -> dict[str, Any]:
+    """Add a ``persist-credentials`` entry to a generated ``with`` mapping."""
+    return {**base, "persist-credentials": value}
+
+
 _with_blocks = st.one_of(
     st.none(),
     st.text(),
     st.integers(),
     st.dictionaries(st.text(min_size=1, max_size=5), json_value, max_size=3),
     st.builds(
-        lambda base, value: {**base, "persist-credentials": value},
+        _with_persist_credentials,
         st.dictionaries(st.text(min_size=1, max_size=5), json_value, max_size=2),
         _persist_credential_values,
     ),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -29,16 +29,23 @@ from tests.utilities import (
     docker_environment,
 )
 
+
+def _json_collections(
+    children: st.SearchStrategy[Any],
+) -> st.SearchStrategy[Any]:
+    """Extend a recursive JSON strategy with bounded list and dict collections."""
+    return st.lists(children, max_size=4) | st.dictionaries(
+        st.text(), children, max_size=4
+    )
+
+
 json_value = st.recursive(
     st.none()
     | st.booleans()
     | st.integers()
     | st.floats(allow_nan=False, allow_infinity=False)
     | st.text(),
-    lambda children: (
-        st.lists(children, max_size=4)
-        | st.dictionaries(st.text(), children, max_size=4)
-    ),
+    _json_collections,
     max_leaves=12,
 )
 
@@ -268,7 +275,7 @@ def test_resolved_socket_from_docker_host_accepts_allowed_unix_path(
     assert (
         _resolved_socket_from_docker_host(f"unix://{socket_path}", (allowed_dir,))
         == socket_path
-    )
+    ), f"expected normalized socket path {socket_path}"
 
 
 def test_docker_environment_preserves_valid_unix_socket(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -189,14 +189,20 @@ def _non_sha_refs(draw: st.DrawFn) -> str:
 @given(path=_action_paths, sha=_full_shas)
 def test_is_pinned_action_accepts_full_sha(path: str, sha: str) -> None:
     """A path pinned to a 40-hex SHA matches only that exact action path."""
-    assert _is_pinned_action(f"{path}@{sha}", path)
-    assert not _is_pinned_action(f"{path}@{sha}", f"{path}-other")
+    assert _is_pinned_action(f"{path}@{sha}", path), (
+        "expected a full 40-hex SHA pin to match its exact action path"
+    )
+    assert not _is_pinned_action(f"{path}@{sha}", f"{path}-other"), (
+        "expected a pinned ref to be rejected for a mismatched action path"
+    )
 
 
 @given(path=_action_paths, ref=_non_sha_refs())
 def test_is_pinned_action_rejects_non_sha_refs(path: str, ref: str) -> None:
     """Refs that are not a full 40-hex commit SHA are never treated as pinned."""
-    assert not _is_pinned_action(f"{path}@{ref}", path)
+    assert not _is_pinned_action(f"{path}@{ref}", path), (
+        "expected a ref that is not a full 40-hex commit SHA to be unpinned"
+    )
 
 
 _json_steps = st.lists(
@@ -217,8 +223,12 @@ def test_step_mappings_keeps_only_mappings_in_order(steps: list[object]) -> None
     """``_step_mappings`` returns exactly the mapping entries, in original order."""
     result = _step_mappings(steps)
 
-    assert result == [step for step in steps if isinstance(step, dict)]
-    assert all(isinstance(step, dict) for step in result)
+    assert result == [step for step in steps if isinstance(step, dict)], (
+        "expected only mapping steps, preserved in their original order"
+    )
+    assert all(isinstance(step, dict) for step in result), (
+        "expected every returned step to be a mapping"
+    )
 
 
 _persist_credential_values = st.sampled_from([True, False, None, 0, 1, "false", "true"])
@@ -251,7 +261,9 @@ def test_disables_credential_persistence_matches_spec(step: dict[str, object]) -
         isinstance(with_block, dict) and with_block.get("persist-credentials") is False
     )
 
-    assert _disables_credential_persistence(step) is expected
+    assert _disables_credential_persistence(step) is expected, (
+        "expected the credential-persistence verdict to match the with-block spec"
+    )
 
 
 def test_read_generated_file_uses_shared_error_contract(tmp_path: Path) -> None:

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -54,6 +54,59 @@
         'workflow_dispatch': None,
       }),
     }),
+    'audit_workflow': dict({
+      'jobs': dict({
+        'audit': dict({
+          'env': dict({
+            'CARGO_TERM_COLOR': 'always',
+          }),
+          'runs-on': 'ubuntu-latest',
+          'steps': list([
+            dict({
+              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'with': dict({
+                'persist-credentials': False,
+              }),
+            }),
+            dict({
+              'name': 'Setup Rust',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+            }),
+            dict({
+              'env': dict({
+                'RUSTFLAGS': '',
+              }),
+              'name': 'Install cargo-audit',
+              'run': 'cargo binstall --no-confirm cargo-audit',
+            }),
+            dict({
+              'name': 'Setup Python for audit manifest extraction',
+              'uses': 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405',
+              'with': dict({
+                'python-version': '3.x',
+              }),
+            }),
+            dict({
+              'name': 'Audit dependencies',
+              'run': 'make audit',
+            }),
+          ]),
+          'timeout-minutes': 30,
+        }),
+      }),
+      'name': 'Scheduled dependency audit',
+      'on': dict({
+        'schedule': list([
+          dict({
+            'cron': '41 6 * * 1',
+          }),
+        ]),
+        'workflow_dispatch': None,
+      }),
+      'permissions': dict({
+        'contents': 'read',
+      }),
+    }),
     'cargo_config': '''
       [unstable]
       codegen-backend = true

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -137,10 +137,12 @@
               'env': dict({
                 'RUSTFLAGS': '',
               }),
+              'if': "github.actor != 'dependabot[bot]'",
               'name': 'Install cargo-audit',
               'run': 'cargo binstall --no-confirm cargo-audit',
             }),
             dict({
+              'if': "github.actor != 'dependabot[bot]'",
               'name': 'Setup Python for audit manifest extraction',
               'uses': 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405',
               'with': dict({
@@ -182,6 +184,7 @@
               ''',
             }),
             dict({
+              'if': "github.actor != 'dependabot[bot]'",
               'name': 'Audit dependencies',
               'run': 'make audit',
             }),

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -14,14 +14,14 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'uses': 'actions/checkout@<sha>',
               'with': dict({
                 'persist-credentials': False,
               }),
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@<sha>',
             }),
             dict({
               'name': 'Install act',
@@ -63,14 +63,14 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'uses': 'actions/checkout@<sha>',
               'with': dict({
                 'persist-credentials': False,
               }),
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@<sha>',
             }),
             dict({
               'env': dict({
@@ -81,7 +81,7 @@
             }),
             dict({
               'name': 'Setup Python for audit manifest extraction',
-              'uses': 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405',
+              'uses': 'actions/setup-python@<sha>',
               'with': dict({
                 'python-version': '3.x',
               }),
@@ -133,7 +133,7 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'uses': 'actions/checkout@<sha>',
               'with': dict({
                 'fetch-depth': 0,
                 'persist-credentials': False,
@@ -141,7 +141,7 @@
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@<sha>',
             }),
             dict({
               'if': "runner.os == 'Linux'",
@@ -161,7 +161,7 @@
             }),
             dict({
               'name': 'Markdown lint',
-              'uses': 'DavidAnson/markdownlint-cli2-action@2df9e28eb87988518ef3880c34edad45d65b1668',
+              'uses': 'DavidAnson/markdownlint-cli2-action@<sha>',
               'with': dict({
                 'globs': '''
                   **/*.md
@@ -173,7 +173,7 @@
             }),
             dict({
               'name': 'Setup uv',
-              'uses': 'astral-sh/setup-uv@12d13f90bc3a5a1971bebad4beb09a4dfa962e91',
+              'uses': 'astral-sh/setup-uv@<sha>',
             }),
             dict({
               'name': 'Check spelling',
@@ -197,7 +197,7 @@
             dict({
               'if': "github.actor != 'dependabot[bot]'",
               'name': 'Setup Python for audit manifest extraction',
-              'uses': 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405',
+              'uses': 'actions/setup-python@<sha>',
               'with': dict({
                 'python-version': '3.x',
               }),
@@ -205,7 +205,7 @@
             dict({
               'id': 'cache-whitaker',
               'name': 'Cache Whitaker installation',
-              'uses': 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae',
+              'uses': 'actions/cache@<sha>',
               'with': dict({
                 'key': 'whitaker-v3-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_VERSION }}',
                 'path': '''
@@ -263,7 +263,7 @@
                 'RUSTFLAGS': '-C link-arg=-fuse-ld=lld',
               }),
               'name': 'Test and Measure Coverage',
-              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@<sha>',
               'with': dict({
                 'format': 'lcov',
                 'output-path': 'lcov.info',
@@ -298,14 +298,14 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'uses': 'actions/checkout@<sha>',
               'with': dict({
                 'persist-credentials': False,
               }),
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@<sha>',
             }),
             dict({
               'if': "runner.os == 'Linux'",
@@ -344,7 +344,7 @@
                 'RUSTFLAGS': '-C link-arg=-fuse-ld=lld',
               }),
               'name': 'Test and Measure Coverage',
-              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@<sha>',
               'with': dict({
                 'format': 'lcov',
                 'output-path': 'lcov.info',
@@ -357,7 +357,7 @@
               }),
               'if': "env.CS_ACCESS_TOKEN != ''",
               'name': 'Upload coverage data to CodeScene',
-              'uses': 'leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/upload-codescene-coverage@<sha>',
               'with': dict({
                 'access-token': '${{ env.CS_ACCESS_TOKEN }}',
                 'format': 'lcov',
@@ -494,13 +494,13 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231',
+              'uses': 'actions/checkout@<sha>',
               'with': dict({
                 'persist-credentials': False,
               }),
             }),
             dict({
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@<sha>',
               'with': dict({
                 'toolchain': 'stable',
               }),
@@ -508,7 +508,7 @@
             dict({
               'id': 'cache-cross',
               'name': 'Cache cross binary',
-              'uses': 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae',
+              'uses': 'actions/cache@<sha>',
               'with': dict({
                 'key': 'cross-${{ env.CROSS_REVISION }}',
                 'path': '~/.cargo/bin/cross',
@@ -529,7 +529,7 @@
             }),
             dict({
               'name': 'Cache cargo registry',
-              'uses': 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae',
+              'uses': 'actions/cache@<sha>',
               'with': dict({
                 'key': "${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}",
                 'path': '''
@@ -564,7 +564,7 @@
             }),
             dict({
               'name': 'Upload release artifact',
-              'uses': 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+              'uses': 'actions/upload-artifact@<sha>',
               'with': dict({
                 'name': '${{ env.BIN_NAME }}-${{ matrix.os }}-${{ matrix.arch }}',
                 'path': 'artifacts/${{ matrix.os }}-${{ matrix.arch }}',
@@ -623,7 +623,7 @@
           'runs-on': 'ubuntu-latest',
           'steps': list([
             dict({
-              'uses': 'actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317',
+              'uses': 'actions/download-artifact@<sha>',
               'with': dict({
                 'path': 'artifacts',
               }),
@@ -632,7 +632,7 @@
               'env': dict({
                 'GITHUB_TOKEN': '${{ secrets.GITHUB_TOKEN }}',
               }),
-              'uses': 'softprops/action-gh-release@403a5240f3837fa857f642062e05aad6bb3391ca',
+              'uses': 'softprops/action-gh-release@<sha>',
               'with': dict({
                 'files': '''
                   artifacts/*/*

--- a/tests/test_template/test_audit_targets.py
+++ b/tests/test_template/test_audit_targets.py
@@ -114,8 +114,7 @@ def test_makefile_rust_audit_honours_documented_ignores(
     output = f"{result.stdout}\n{result.stderr}"
     assert result.returncode == 0, output
     assert log_path.read_text(encoding="utf-8") == (
-        f"{project.path}|audit --ignore RUSTSEC-2017-0001 "
-        "--ignore RUSTSEC-2024-9999\n"
+        f"{project.path}|audit --ignore RUSTSEC-2017-0001 --ignore RUSTSEC-2024-9999\n"
     ), "expected documented ignores to be passed as cargo-audit --ignore flags"
 
 

--- a/tests/test_template/test_compilation.py
+++ b/tests/test_template/test_compilation.py
@@ -11,9 +11,7 @@ from tests.helpers.rendering import APP, LIB, render_project
 
 
 @pytest.mark.parametrize("flavour", [LIB, APP])
-def test_template_compiles(
-    tmp_path: Path, copier: CopierFixture, flavour: str
-) -> None:
+def test_template_compiles(tmp_path: Path, copier: CopierFixture, flavour: str) -> None:
     """Generated project compiles with cargo check."""
     project = render_project(
         tmp_path,

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -19,18 +19,24 @@ _PINNED_USES_RE = re.compile(r"^(?P<ref>.+)@[0-9a-f]{40}$")
 
 def _redact_pinned_shas(value: object) -> object:
     """Replace 40-hex SHA-pinned ``uses`` refs with a stable placeholder."""
-    if isinstance(value, dict):
-        return {
-            key: (
-                _PINNED_USES_RE.sub(r"\g<ref>@<sha>", item)
-                if key == "uses" and isinstance(item, str)
-                else _redact_pinned_shas(item)
-            )
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_pinned_shas(item) for item in value]
-    return value
+    match value:
+        case dict() as mapping:
+            return {
+                key: _redact_mapping_entry(key, item) for key, item in mapping.items()
+            }
+        case list() as sequence:
+            return [_redact_pinned_shas(item) for item in sequence]
+        case _:
+            return value
+
+
+def _redact_mapping_entry(key: object, item: object) -> object:
+    """Redact a pinned ``uses`` ref, otherwise recurse into the entry."""
+    match (key, item):
+        case ("uses", str() as pinned):
+            return _PINNED_USES_RE.sub(r"\g<ref>@<sha>", pinned)
+        case _:
+            return _redact_pinned_shas(item)
 
 
 def test_generated_structured_file_snapshots(

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -32,6 +32,9 @@ def test_generated_structured_file_snapshots(
     ci_workflow = parse_yaml_mapping(
         read_generated_text(project / ".github/workflows/ci.yml"), "CI workflow"
     )
+    audit_workflow = parse_yaml_mapping(
+        read_generated_text(project / ".github/workflows/audit.yml"), "audit workflow"
+    )
     act_workflow = parse_yaml_mapping(
         read_generated_text(project / ".github/workflows/act-validation.yml"),
         "act-validation workflow",
@@ -49,10 +52,12 @@ def test_generated_structured_file_snapshots(
         "cargo_config": cargo_config,
         "makefile": makefile_snapshot,
         "act_workflow": act_workflow,
+        "audit_workflow": audit_workflow,
         "ci_workflow": ci_workflow,
         "coverage_main_workflow": coverage_main_workflow,
         "release_workflow": release_workflow,
     } == snapshot, (
         "Snapshot mismatch for template outputs (cargo_config, makefile, "
-        "act_workflow, ci_workflow, coverage_main_workflow, release_workflow)"
+        "act_workflow, audit_workflow, ci_workflow, coverage_main_workflow, "
+        "release_workflow)"
     )

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -18,13 +18,7 @@ _PINNED_USES_RE = re.compile(r"^(?P<ref>.+)@[0-9a-f]{40}$")
 
 
 def _redact_pinned_shas(value: object) -> object:
-    """Replace 40-hex SHA-pinned ``uses`` refs with a stable placeholder.
-
-    Snapshots must not embed pinned action SHAs; Dependabot bumps would
-    otherwise break the snapshot in lockstep with routine dependency updates.
-    The workflow contract helpers retain the full 40-hex SHA validation on the
-    raw rendered text, so pinning is still enforced elsewhere.
-    """
+    """Replace 40-hex SHA-pinned ``uses`` refs with a stable placeholder."""
     if isinstance(value, dict):
         return {
             key: (

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -133,32 +133,38 @@ _workflow_like = st.recursive(
 
 def _iter_uses_values(value: object) -> Iterator[str]:
     """Yield every ``uses`` string leaf in a nested workflow structure."""
-    if isinstance(value, dict):
-        for key, item in value.items():
-            if key == "uses" and isinstance(item, str):
-                yield item
-            else:
+    match value:
+        case dict() as mapping:
+            for key, item in mapping.items():
+                match (key, item):
+                    case ("uses", str() as uses):
+                        yield uses
+                    case _:
+                        yield from _iter_uses_values(item)
+        case list() as sequence:
+            for item in sequence:
                 yield from _iter_uses_values(item)
-    elif isinstance(value, list):
-        for item in value:
-            yield from _iter_uses_values(item)
 
 
 def _same_shape(original: object, redacted: object) -> bool:
     """Return whether two structures share container types, keys, and lengths."""
-    if isinstance(original, dict):
-        return (
-            isinstance(redacted, dict)
-            and original.keys() == redacted.keys()
-            and all(_same_shape(original[key], redacted[key]) for key in original)
-        )
-    if isinstance(original, list):
-        return (
-            isinstance(redacted, list)
-            and len(original) == len(redacted)
-            and all(_same_shape(a, b) for a, b in zip(original, redacted, strict=True))
-        )
-    return type(original) is type(redacted)
+    match original, redacted:
+        case dict() as original_map, dict() as redacted_map:
+            return original_map.keys() == redacted_map.keys() and all(
+                _same_shape(original_map[key], redacted_map[key])
+                for key in original_map
+            )
+        case dict(), _:
+            return False
+        case list() as original_seq, list() as redacted_seq:
+            return len(original_seq) == len(redacted_seq) and all(
+                _same_shape(a, b)
+                for a, b in zip(original_seq, redacted_seq, strict=True)
+            )
+        case list(), _:
+            return False
+        case _:
+            return type(original) is type(redacted)
 
 
 @given(structure=_workflow_like)
@@ -168,12 +174,18 @@ def test_redact_pinned_shas_removes_every_pinned_sha(structure: object) -> None:
 
     assert all(
         _PINNED_USES_RE.match(uses) is None for uses in _iter_uses_values(redacted)
+    ), "expected redaction to strip every pinned SHA from uses refs"
+    assert _redact_pinned_shas(redacted) == redacted, (
+        "expected redaction to be idempotent"
     )
-    assert _redact_pinned_shas(redacted) == redacted
-    assert _same_shape(structure, redacted)
+    assert _same_shape(structure, redacted), (
+        "expected redaction to preserve the structure shape"
+    )
 
 
 @given(path=_action_paths, sha=_full_shas)
 def test_redact_pinned_shas_preserves_action_path(path: str, sha: str) -> None:
     """A pinned ``uses`` ref keeps its action path and drops only the SHA."""
-    assert _redact_pinned_shas({"uses": f"{path}@{sha}"}) == {"uses": f"{path}@<sha>"}
+    assert _redact_pinned_shas({"uses": f"{path}@{sha}"}) == {
+        "uses": f"{path}@<sha>"
+    }, "expected redaction to replace only the SHA and keep the action path"

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -17,6 +17,9 @@ from tests.helpers.rendering import APP, render_project
 _PINNED_USES_RE = re.compile(r"^(?P<ref>.+)@[0-9a-f]{40}$")
 
 
+# FIXME(https://github.com/leynos/agent-template-rust/issues/72): replace this
+# hand-rolled traversal with a syrupy ``matcher=`` as part of the planned
+# snapshot-testing overhaul (once AST-aware Markdown snapshots are ready).
 def _redact_pinned_shas(value: object) -> object:
     """Replace 40-hex SHA-pinned ``uses`` refs with a stable placeholder."""
     match value:

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
+from hypothesis import given
+from hypothesis import strategies as st
 from pytest_copier.plugin import CopierFixture
 from syrupy.assertion import SnapshotAssertion
 
@@ -94,3 +97,83 @@ def test_generated_structured_file_snapshots(
         "act_workflow, audit_workflow, ci_workflow, coverage_main_workflow, "
         "release_workflow)"
     )
+
+
+_HEX_ALPHABET = "0123456789abcdef"
+_action_paths = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789/-._", min_size=1, max_size=20
+)
+_full_shas = st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40)
+_pinned_uses = st.builds(lambda path, sha: f"{path}@{sha}", _action_paths, _full_shas)
+_unpinned_uses = st.one_of(
+    st.builds(
+        lambda path, ref: f"{path}@{ref}",
+        _action_paths,
+        st.sampled_from(("main", "v1", "rolling")),
+    ),
+    st.text(max_size=20),
+)
+_uses_refs = st.one_of(_pinned_uses, _unpinned_uses)
+_workflow_like = st.recursive(
+    st.one_of(
+        st.none(),
+        st.booleans(),
+        st.integers(),
+        st.text(max_size=10),
+        st.fixed_dictionaries({"uses": _uses_refs}),
+    ),
+    lambda children: st.one_of(
+        st.lists(children, max_size=3),
+        st.dictionaries(st.text(min_size=1, max_size=5), children, max_size=3),
+        st.fixed_dictionaries({"uses": _uses_refs}),
+    ),
+    max_leaves=15,
+)
+
+
+def _iter_uses_values(value: object) -> Iterator[str]:
+    """Yield every ``uses`` string leaf in a nested workflow structure."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "uses" and isinstance(item, str):
+                yield item
+            else:
+                yield from _iter_uses_values(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_uses_values(item)
+
+
+def _same_shape(original: object, redacted: object) -> bool:
+    """Return whether two structures share container types, keys, and lengths."""
+    if isinstance(original, dict):
+        return (
+            isinstance(redacted, dict)
+            and original.keys() == redacted.keys()
+            and all(_same_shape(original[key], redacted[key]) for key in original)
+        )
+    if isinstance(original, list):
+        return (
+            isinstance(redacted, list)
+            and len(original) == len(redacted)
+            and all(_same_shape(a, b) for a, b in zip(original, redacted, strict=True))
+        )
+    return type(original) is type(redacted)
+
+
+@given(structure=_workflow_like)
+def test_redact_pinned_shas_removes_every_pinned_sha(structure: object) -> None:
+    """Redaction strips every pinned SHA, is idempotent, and preserves shape."""
+    redacted = _redact_pinned_shas(structure)
+
+    assert all(
+        _PINNED_USES_RE.match(uses) is None for uses in _iter_uses_values(redacted)
+    )
+    assert _redact_pinned_shas(redacted) == redacted
+    assert _same_shape(structure, redacted)
+
+
+@given(path=_action_paths, sha=_full_shas)
+def test_redact_pinned_shas_preserves_action_path(path: str, sha: str) -> None:
+    """A pinned ``uses`` ref keeps its action path and drops only the SHA."""
+    assert _redact_pinned_shas({"uses": f"{path}@{sha}"}) == {"uses": f"{path}@<sha>"}

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -104,16 +105,37 @@ _action_paths = st.text(
     alphabet="abcdefghijklmnopqrstuvwxyz0123456789/-._", min_size=1, max_size=20
 )
 _full_shas = st.text(alphabet=_HEX_ALPHABET, min_size=40, max_size=40)
-_pinned_uses = st.builds(lambda path, sha: f"{path}@{sha}", _action_paths, _full_shas)
+
+
+def _pinned_uses_ref(path: str, sha: str) -> str:
+    """Build a ``uses`` ref pinned to a full 40-hex commit SHA."""
+    return f"{path}@{sha}"
+
+
+def _unpinned_uses_ref(path: str, ref: str) -> str:
+    """Build a ``uses`` ref pointing at a mutable branch or tag."""
+    return f"{path}@{ref}"
+
+
+_pinned_uses = st.builds(_pinned_uses_ref, _action_paths, _full_shas)
 _unpinned_uses = st.one_of(
     st.builds(
-        lambda path, ref: f"{path}@{ref}",
-        _action_paths,
-        st.sampled_from(("main", "v1", "rolling")),
+        _unpinned_uses_ref, _action_paths, st.sampled_from(("main", "v1", "rolling"))
     ),
     st.text(max_size=20),
 )
 _uses_refs = st.one_of(_pinned_uses, _unpinned_uses)
+
+
+def _workflow_children(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
+    """Extend the recursive workflow strategy with lists, dicts, and uses leaves."""
+    return st.one_of(
+        st.lists(children, max_size=3),
+        st.dictionaries(st.text(min_size=1, max_size=5), children, max_size=3),
+        st.fixed_dictionaries({"uses": _uses_refs}),
+    )
+
+
 _workflow_like = st.recursive(
     st.one_of(
         st.none(),
@@ -122,11 +144,7 @@ _workflow_like = st.recursive(
         st.text(max_size=10),
         st.fixed_dictionaries({"uses": _uses_refs}),
     ),
-    lambda children: st.one_of(
-        st.lists(children, max_size=3),
-        st.dictionaries(st.text(min_size=1, max_size=5), children, max_size=3),
-        st.fixed_dictionaries({"uses": _uses_refs}),
-    ),
+    _workflow_children,
     max_leaves=15,
 )
 

--- a/tests/test_template/test_snapshots.py
+++ b/tests/test_template/test_snapshots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from pytest_copier.plugin import CopierFixture
@@ -12,6 +13,30 @@ from tests.helpers.generated_files import (
     read_generated_text,
 )
 from tests.helpers.rendering import APP, render_project
+
+_PINNED_USES_RE = re.compile(r"^(?P<ref>.+)@[0-9a-f]{40}$")
+
+
+def _redact_pinned_shas(value: object) -> object:
+    """Replace 40-hex SHA-pinned ``uses`` refs with a stable placeholder.
+
+    Snapshots must not embed pinned action SHAs; Dependabot bumps would
+    otherwise break the snapshot in lockstep with routine dependency updates.
+    The workflow contract helpers retain the full 40-hex SHA validation on the
+    raw rendered text, so pinning is still enforced elsewhere.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                _PINNED_USES_RE.sub(r"\g<ref>@<sha>", item)
+                if key == "uses" and isinstance(item, str)
+                else _redact_pinned_shas(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_pinned_shas(item) for item in value]
+    return value
 
 
 def test_generated_structured_file_snapshots(
@@ -48,15 +73,20 @@ def test_generated_structured_file_snapshots(
         "release workflow",
     )
 
-    assert {
-        "cargo_config": cargo_config,
-        "makefile": makefile_snapshot,
-        "act_workflow": act_workflow,
-        "audit_workflow": audit_workflow,
-        "ci_workflow": ci_workflow,
-        "coverage_main_workflow": coverage_main_workflow,
-        "release_workflow": release_workflow,
-    } == snapshot, (
+    assert (
+        _redact_pinned_shas(
+            {
+                "cargo_config": cargo_config,
+                "makefile": makefile_snapshot,
+                "act_workflow": act_workflow,
+                "audit_workflow": audit_workflow,
+                "ci_workflow": ci_workflow,
+                "coverage_main_workflow": coverage_main_workflow,
+                "release_workflow": release_workflow,
+            }
+        )
+        == snapshot
+    ), (
         "Snapshot mismatch for template outputs (cargo_config, makefile, "
         "act_workflow, audit_workflow, ci_workflow, coverage_main_workflow, "
         "release_workflow)"

--- a/tests/test_template/test_tooling_contracts.py
+++ b/tests/test_template/test_tooling_contracts.py
@@ -13,12 +13,14 @@ from tests.helpers.generated_files import (
     read_generated_text,
     require_mapping,
     require_optional_mapping,
+    require_sequence,
 )
 from tests.helpers.rendering import APP, LIB, render_project
 from tests.helpers.tooling_contracts import (
     assert_coverage_main_workflow_contract,
     assert_generated_tooling_contracts,
 )
+from tests.helpers.tooling_contracts.workflows import _assert_ci_workflow_contracts
 
 
 @pytest.mark.parametrize(
@@ -98,3 +100,32 @@ def test_generated_tooling_contracts(
     assert 'accepted = ["Flavored", "mold"]' in typos_overlay
     assert "DEFAULT_BASE_URL" in spelling_generator
     assert "_local_cache_is_current" in spelling_core
+
+
+def test_ci_contract_rejects_unguarded_duplicate_audit_step(
+    tmp_path: Path, copier: CopierFixture
+) -> None:
+    """Reject a duplicate audit step that would run on Dependabot pull requests."""
+    project = render_project(
+        tmp_path,
+        copier,
+        project_name="ToolingExample",
+        package_name="tooling_example",
+        flavour=APP,
+    )
+    ci_workflow = read_generated_text(project / ".github/workflows/ci.yml")
+    act_workflow = read_generated_text(project / ".github/workflows/act-validation.yml")
+    test_stub = read_generated_text(project / "tests/stub.rs")
+    parsed_ci_workflow = parse_yaml_mapping(ci_workflow, "CI workflow")
+
+    jobs = require_mapping(parsed_ci_workflow, "jobs", "CI workflow")
+    build_test = require_mapping(jobs, "build-test", "CI workflow jobs")
+    steps = require_sequence(build_test, "steps", "CI build-test job")
+    steps.append({"name": "Audit dependencies", "run": "make audit"})
+
+    with pytest.raises(
+        AssertionError, match="each audit-specific CI step exactly once"
+    ):
+        _assert_ci_workflow_contracts(
+            parsed_ci_workflow, ci_workflow, act_workflow, test_stub
+        )

--- a/tests/test_template/test_tooling_contracts.py
+++ b/tests/test_template/test_tooling_contracts.py
@@ -52,6 +52,7 @@ def test_generated_tooling_contracts(
     makefile = read_generated_text(project / "Makefile")
     cargo_config = read_generated_text(project / ".cargo/config.toml")
     ci_workflow = read_generated_text(project / ".github/workflows/ci.yml")
+    audit_workflow = read_generated_text(project / ".github/workflows/audit.yml")
     act_workflow = read_generated_text(project / ".github/workflows/act-validation.yml")
     coverage_main_workflow = read_generated_text(
         project / ".github/workflows/coverage-main.yml"
@@ -84,6 +85,7 @@ def test_generated_tooling_contracts(
         rust_toolchain=rust_toolchain,
         parsed_ci_workflow=parsed_ci_workflow,
         ci_workflow=ci_workflow,
+        audit_workflow=audit_workflow,
         act_workflow=act_workflow,
         docs_contents=docs_contents,
         repository_layout=repository_layout,

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -52,7 +53,9 @@ def _resolved_socket_from_docker_host(
 def _user_podman_socket() -> Path:
     """Return the current user's Podman socket path."""
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    runtime_path = Path(runtime_dir) if runtime_dir else Path(f"/run/user/{os.getuid()}")
+    runtime_path = (
+        Path(runtime_dir) if runtime_dir else Path(f"/run/user/{os.getuid()}")
+    )
     return runtime_path.expanduser().resolve() / "podman" / "podman.sock"
 
 
@@ -97,7 +100,7 @@ def docker_environment() -> dict[str, str]:
     return env
 
 
-def container_daemon_socket(env: dict[str, str] | None = None) -> str | None:
+def container_daemon_socket(env: Mapping[str, str] | None = None) -> str | None:
     """Return a validated ``act`` container daemon socket value."""
     should_fallback = env is None
     env = os.environ if env is None else env


### PR DESCRIPTION
## Summary

- Conditions the templated CI's `make audit` step — and its audit-only prerequisites (`cargo-audit` install and the Python setup for manifest extraction) — on `github.actor != 'dependabot[bot]'`.
- Adds a templated weekly scheduled audit workflow (`audit.yml`) as the compensating control, reusing the template's existing pinned action refs.

## Motivation

`make audit` reports advisories against the whole lockfile, so in generated projects a newly published advisory fails every open Dependabot PR regardless of its content, deadlocking Dependabot auto-merge (observed on leynos/corbusier#120, where even Dependabot's own fix for a vite advisory was blocked by unrelated advisories). The same change has been applied directly to the twelve existing estate repositories with `make audit` gates; this PR brings the template in line so newly generated projects inherit it. Human pull requests keep the full audit gate.

## Test plan

- [x] `actionlint` clean on both templated workflow files
- [ ] `act-validation` template render passes in CI

## References

- Lody session: https://lody.ai/leynos/sessions/21ce026c-1cba-4199-944c-16407f297891
