### PR TITLE
Install Whitaker from the released installer in generated CI

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -64,12 +64,13 @@ jobs:
       - name: Install Whitaker
         env:
           RUSTFLAGS: ""
+          WHITAKER_CACHE_HIT: ${{ steps.cache-whitaker.outputs.cache-hit }}
         run: |
           set -euo pipefail
-          echo "Whitaker cache hit: ${{ steps.cache-whitaker.outputs.cache-hit }}"
-          if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
+          echo "Whitaker cache hit: ${WHITAKER_CACHE_HIT}"
+          if [ "${WHITAKER_CACHE_HIT}" != "true" ]; then
             echo "Installing whitaker-installer ${WHITAKER_INSTALLER_VERSION}"
-            cargo binstall --no-confirm \
+            cargo binstall --no-confirm --locked \
               whitaker-installer@"${WHITAKER_INSTALLER_VERSION}"
           fi
           whitaker-installer --cranelift

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
         with:
@@ -60,7 +60,7 @@ jobs:
             ~/.local/bin/whitaker
             ~/.dylint_drivers
             ~/.local/share/whitaker
-          key: whitaker-v2-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_REV }}
+          key: whitaker-v3-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Install Whitaker
         env:
           RUSTFLAGS: ""
@@ -68,11 +68,9 @@ jobs:
           set -euo pipefail
           echo "Whitaker cache hit: ${{ steps.cache-whitaker.outputs.cache-hit }}"
           if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
-            echo "Installing Whitaker installer at ${WHITAKER_INSTALLER_REV}"
-            cargo install --locked \
-              --git https://github.com/leynos/whitaker \
-              --rev "${WHITAKER_INSTALLER_REV}" \
-              whitaker-installer
+            echo "Installing whitaker-installer ${WHITAKER_INSTALLER_VERSION}"
+            cargo binstall --no-confirm \
+              whitaker-installer@"${WHITAKER_INSTALLER_VERSION}"
           fi
           whitaker-installer --cranelift
           echo "Whitaker binary: $(command -v whitaker || true)"

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -187,7 +187,7 @@ def _assert_ci_workflow_contracts(
     assert "Whitaker cache hit:" in ci_workflow, (
         "expected generated CI workflow to log Whitaker cache status"
     )
-    assert "Installing Whitaker installer at" in ci_workflow, (
+    assert "Installing whitaker-installer" in ci_workflow, (
         "expected generated CI workflow to log Whitaker installation"
     )
     assert "Whitaker binary:" in ci_workflow, (

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -160,14 +160,15 @@
             dict({
               'env': dict({
                 'RUSTFLAGS': '',
+                'WHITAKER_CACHE_HIT': '${{ steps.cache-whitaker.outputs.cache-hit }}',
               }),
               'name': 'Install Whitaker',
               'run': '''
                 set -euo pipefail
-                echo "Whitaker cache hit: ${{ steps.cache-whitaker.outputs.cache-hit }}"
-                if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
+                echo "Whitaker cache hit: ${WHITAKER_CACHE_HIT}"
+                if [ "${WHITAKER_CACHE_HIT}" != "true" ]; then
                   echo "Installing whitaker-installer ${WHITAKER_INSTALLER_VERSION}"
-                  cargo binstall --no-confirm \
+                  cargo binstall --no-confirm --locked \
                     whitaker-installer@"${WHITAKER_INSTALLER_VERSION}"
                 fi
                 whitaker-installer --cranelift

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -72,7 +72,7 @@
           'env': dict({
             'BUILD_PROFILE': 'debug',
             'CARGO_TERM_COLOR': 'always',
-            'WHITAKER_INSTALLER_REV': 'f768c2e53c47df13658af1168a67851d388750bf',
+            'WHITAKER_INSTALLER_VERSION': '0.2.5',
           }),
           'permissions': dict({
             'contents': 'read',
@@ -147,7 +147,7 @@
               'name': 'Cache Whitaker installation',
               'uses': 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae',
               'with': dict({
-                'key': 'whitaker-v2-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_REV }}',
+                'key': 'whitaker-v3-${{ runner.os }}-${{ env.WHITAKER_INSTALLER_VERSION }}',
                 'path': '''
                   ~/.cargo/bin/whitaker-installer
                   ~/.local/bin/whitaker
@@ -166,11 +166,9 @@
                 set -euo pipefail
                 echo "Whitaker cache hit: ${{ steps.cache-whitaker.outputs.cache-hit }}"
                 if [ "${{ steps.cache-whitaker.outputs.cache-hit }}" != "true" ]; then
-                  echo "Installing Whitaker installer at ${WHITAKER_INSTALLER_REV}"
-                  cargo install --locked \
-                    --git https://github.com/leynos/whitaker \
-                    --rev "${WHITAKER_INSTALLER_REV}" \
-                    whitaker-installer
+                  echo "Installing whitaker-installer ${WHITAKER_INSTALLER_VERSION}"
+                  cargo binstall --no-confirm \
+                    whitaker-installer@"${WHITAKER_INSTALLER_VERSION}"
                 fi
                 whitaker-installer --cranelift
                 echo "Whitaker binary: $(command -v whitaker || true)"


### PR DESCRIPTION
## Summary

This branch aligns the template's generated CI with the estate-standard Whitaker installation pattern used in leynos/netsuke#410 and the tier 1–2 rollout. The generated workflow previously built `whitaker-installer` from a pinned git revision; it now installs the released 0.2.5 crate via `cargo binstall`, keeping the `--cranelift` flag because generated projects use the Cranelift debug backend. Projects rendered from this template therefore pick up the maintained release channel instead of a fixed commit.

## Review walkthrough

- Start with [template/.github/workflows/ci.yml](https://github.com/leynos/agent-template-rust/blob/adopt-whitaker/template/.github/workflows/ci.yml): the `WHITAKER_INSTALLER_REV` environment variable becomes `WHITAKER_INSTALLER_VERSION: '0.2.5'`, the cache key moves to `whitaker-v3-…` so stale rev-keyed caches are ignored, and the install step uses the guarded `cargo binstall`.
- [tests/helpers/tooling_contracts/workflows.py](https://github.com/leynos/agent-template-rust/blob/adopt-whitaker/tests/helpers/tooling_contracts/workflows.py) updates the contract assertion to the new installation log line.
- [tests/test_template/__snapshots__/test_snapshots.ambr](https://github.com/leynos/agent-template-rust/blob/adopt-whitaker/tests/test_template/__snapshots__/test_snapshots.ambr) is the regenerated syrupy snapshot of the rendered workflow.

## Validation

- `make test` (render, compilation, lint-target, contract, and snapshot suites): 50 passed, 1 xfailed.
- `WITH_ACT=1 make test` (act-validation suite against a Podman socket, act v0.2.80): 50 passed, 1 xfailed.

## Notes

The template's `lint` target and Makefile Whitaker resolution are unchanged; only the installation channel in the generated CI moves to the released crate.
