### PR TITLE
Assert shared-actions pins by shape, not exact SHA

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -93,9 +93,14 @@ Keep generated-project behaviour in `template/` and prove it from parent tests
 under `tests/`. Prefer assertions that render a real project and run public
 generated commands over checks that only inspect template source text.
 
-GitHub Actions in both parent and generated workflows are SHA-pinned. When an
-action revision changes, update the rendered workflow assertions that lock the
-pin.
+GitHub Actions in both parent and generated workflows are SHA-pinned.
+Dependabot owns bumping `leynos/shared-actions` pins in both the parent
+workflows and the templates it renders; rendered workflow assertions in
+`tests/helpers/tooling_contracts/workflows.py` check the *shape* of a
+shared-actions `uses:` ref (correct path, pinned to a full 40-hex commit SHA)
+rather than the exact SHA value, so a routine Dependabot bump does not fail
+the contract. See `template/docs/developers-guide.md.jinja`'s "Workflow pins
+and Dependabot" section for the policy that generated projects inherit.
 
 ## Test Helper Layout
 

--- a/template/docs/developers-guide.md.jinja
+++ b/template/docs/developers-guide.md.jinja
@@ -42,3 +42,38 @@ RustSec advisories that affect unused or tooling-only dependency paths. Keep
 each ignore tied to a documented runtime impact analysis, and remove it when
 the affected dependency leaves the graph or the project starts using the
 advised runtime path.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/helpers/tooling_contracts/workflows.py
+++ b/tests/helpers/tooling_contracts/workflows.py
@@ -1,13 +1,30 @@
-"""Assert rendered GitHub Actions contracts for generated Rust projects."""
+"""Assert rendered GitHub Actions contracts for generated Rust projects.
+
+Shared-actions ``uses:`` refs are asserted by shape (correct reusable-workflow
+or action path, pinned to a full 40-hex commit SHA), not by exact SHA value.
+Dependabot owns bumping the pinned SHA; these contracts must not fail in
+lockstep with routine bump PRs.
+"""
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from tests.helpers.generated_files import (
     parse_yaml_mapping,
     require_mapping,
     require_sequence,
+)
+
+_GENERATE_COVERAGE_USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/actions/generate-coverage@[0-9a-f]{40}$"
+)
+_UPLOAD_CODESCENE_COVERAGE_USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/actions/upload-codescene-coverage@[0-9a-f]{40}$"
+)
+_SETUP_RUST_USES_TEXT_RE = re.compile(
+    r"leynos/shared-actions/\.github/actions/setup-rust@[0-9a-f]{40}"
 )
 
 
@@ -57,11 +74,11 @@ def assert_ci_coverage_action_contract(ci_workflow: str) -> None:
     ]
     assert len(coverage_steps) == 1, "expected one shared coverage action step"
     coverage_step = coverage_steps[0]
-    assert (
-        coverage_step.get("uses")
-        == "leynos/shared-actions/.github/actions/generate-coverage"
-        "@927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-    ), "expected CI to use the pinned shared coverage action"
+    coverage_uses = str(coverage_step.get("uses", ""))
+    assert _GENERATE_COVERAGE_USES_RE.match(coverage_uses), (
+        "expected CI to use the shared coverage action pinned to a full "
+        f"40-hex commit SHA, got {coverage_uses!r}"
+    )
     coverage_inputs = require_mapping(coverage_step, "with", "coverage step")
     assert coverage_inputs.get("output-path") == "lcov.info", (
         "expected CI coverage output path to match the act assertion"
@@ -132,11 +149,11 @@ def assert_coverage_main_workflow_contract(coverage_main_workflow: str) -> None:
     assert len(upload_steps) == 1, (
         "expected coverage-main.yml to upload coverage to CodeScene"
     )
-    assert (
-        upload_steps[0].get("uses")
-        == "leynos/shared-actions/.github/actions/upload-codescene-coverage"
-        "@927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-    ), "expected coverage-main.yml to pin the shared upload action"
+    upload_uses = str(upload_steps[0].get("uses", ""))
+    assert _UPLOAD_CODESCENE_COVERAGE_USES_RE.match(upload_uses), (
+        "expected coverage-main.yml to use the shared upload action pinned "
+        f"to a full 40-hex commit SHA, got {upload_uses!r}"
+    )
     assert upload_steps[0].get("if") == "env.CS_ACCESS_TOKEN != ''", (
         "expected coverage-main.yml upload to skip cleanly without a token"
     )
@@ -221,10 +238,10 @@ def _assert_ci_workflow_contracts(
     assert "Cache Whitaker installation" in ci_workflow, (
         "expected generated CI workflow to cache Whitaker installation"
     )
-    assert (
-        "leynos/shared-actions/.github/actions/setup-rust"
-        "@927edd45ae77be4251a8a18ca9eb5613a2e32cbd" in ci_workflow
-    ), "expected generated CI workflow to use the pinned shared setup-rust action"
+    assert _SETUP_RUST_USES_TEXT_RE.search(ci_workflow), (
+        "expected generated CI workflow to use the shared setup-rust action "
+        "pinned to a full 40-hex commit SHA"
+    )
     build_test_checkout = [
         step
         for step in steps


### PR DESCRIPTION
## Summary

- The generated-project tooling contract test asserted the exact pinned
  `leynos/shared-actions` commit SHA for the `setup-rust`,
  `generate-coverage`, and `upload-codescene-coverage` callers. Every
  routine Dependabot bump of that SHA broke the test until someone
  hand-edited the expected constant.
- Replace the three exact-SHA equality checks in
  `tests/helpers/tooling_contracts/workflows.py` with regexes that
  confirm the `uses:` ref targets the correct `shared-actions` path and
  is pinned to a full 40-hex commit SHA, without asserting which SHA.
  All other structural assertions (triggers, credential persistence,
  coverage inputs, ratchet flag, act-validation separation) are
  unchanged.
- The template's own rendered workflow pins are untouched; Dependabot
  keeps owning those.
- Document the "assert shape, not exact SHA" policy in the generated
  project's developers' guide
  (`template/docs/developers-guide.md.jinja`), and correct the parent
  developers' guide's now-stale note that told contributors to update
  rendered workflow assertions in lockstep with pin bumps.
- `dependabot.yml` already has a `github-actions` ecosystem entry with
  `directory: "/"` in both the parent repo and the template it renders,
  so no change was needed there.

## Review walkthrough

- `tests/helpers/tooling_contracts/workflows.py`: added three
  module-level compiled regexes (`_GENERATE_COVERAGE_USES_RE`,
  `_UPLOAD_CODESCENE_COVERAGE_USES_RE`, `_SETUP_RUST_USES_TEXT_RE`) and
  swapped the exact-SHA `assert ... == "...@927edd45..."` checks for
  regex matches in `assert_ci_coverage_action_contract`,
  `assert_coverage_main_workflow_contract`, and
  `_assert_ci_workflow_contracts`.
- `template/docs/developers-guide.md.jinja`: new "Workflow pins and
  Dependabot" subsection using the estate's canonical policy wording.
- `docs/developers-guide.md`: reworded the "Design Notes" paragraph
  that previously instructed contributors to keep rendered workflow
  assertions locked to the pin.

## Validation

- `uv run --with pytest-copier --with pyyaml --with syrupy --with
  make-parser --with hypothesis pytest tests/test_helpers.py
  tests/test_template/test_tooling_contracts.py -q` — 31 passed.
- `uv run ... pytest tests/test_template/test_snapshots.py -q` — 1
  passed (unaffected, since the actual rendered workflow pin value is
  unchanged).
- `uv run ... pytest tests/ -q` — 55 passed, 1 skipped, 3 pre-existing
  failures in `test_lint_targets.py::test_makefile_resolves_whitaker_fallback`
  reproduced identically on unmodified `main`; unrelated to this change.
- `make spelling` regenerated `typos.toml`; no drift (file unchanged).
- Reasoned/confirmed in a throwaway script that the new regexes match
  both the current pinned SHA and a hypothetical different 40-hex SHA,
  and reject a mutable ref such as `main`.
