### PR TITLE
Prescribe the uv --script shebang and test it

### DIFF
--- a/scripts/generate_typos_config.py
+++ b/scripts/generate_typos_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = []

--- a/template/docs/scripting-standards.md
+++ b/template/docs/scripting-standards.md
@@ -33,8 +33,11 @@ as a default.
   inline.
 - Each script starts with an `uv` script block, so runtime and dependency
   expectations travel with the file. Prefer the shebang
-  `#!/usr/bin/env -S uv run python` followed by the metadata block shown in the
-  example below.
+  `#!/usr/bin/env -S uv run --script` followed by the metadata block shown in
+  the example below. The `--script` flag is required: `uv run python` executes
+  the interpreter directly and ignores the inline metadata block, so a script
+  invoked that way fails at import time on any machine without its
+  dependencies preinstalled.
 - External processes are invoked via [`plumbum`](https://plumbum.readthedocs.io)
   to provide structured command execution rather than ad‑hoc shell strings.
 - File‑system interactions use `pathlib.Path`. Higher‑level operations (for
@@ -44,7 +47,7 @@ as a default.
 ### Minimal script (no CLI)
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["plumbum", "cmd-mox"]
@@ -74,7 +77,7 @@ Employ Cyclopts when a script requires parameters, particularly under CI with
 `INPUT_*` variables.
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]
@@ -285,7 +288,7 @@ except FileNotFoundError:
 ## Cyclopts + Plumbum + Pathlib together (reference script)
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]

--- a/template/scripts/generate_typos_config.py
+++ b/template/scripts/generate_typos_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = []

--- a/tests/test_scripting_shebang.py
+++ b/tests/test_scripting_shebang.py
@@ -1,0 +1,101 @@
+"""Validate the uv script shebang prescribed by the scripting standard.
+
+``#!/usr/bin/env -S uv run python`` executes the interpreter directly and
+ignores the PEP 723 inline-metadata block, so a directly invoked script
+fails at import time on machines without its dependencies preinstalled.
+The prescribed form is ``#!/usr/bin/env -S uv run --script``. These tests
+guard the repository and template trees against the broken form and prove
+the prescribed form resolves inline dependencies before execution.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BROKEN_SHEBANG = "#!/usr/bin/env -S uv run python\n"
+PRESCRIBED_SHEBANG = "#!/usr/bin/env -S uv run --script\n"
+
+PROBE_SCRIPT = """\
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["packaging"]
+# ///
+import packaging
+
+print(packaging.__name__)
+"""
+
+
+def _pep723_scripts() -> list[Path]:
+    """Return every tracked Python file opening with a PEP 723 metadata block.
+
+    A PEP 723 script declares its block at the top of the file (immediately
+    after the shebang), so only the first few lines are examined; embedded
+    fixture strings elsewhere in a file do not count.
+    """
+    scripts = []
+    for path in sorted(REPO_ROOT.glob("**/*.py")):
+        if any(part in {".git", ".venv", "__pycache__"} for part in path.parts):
+            continue
+        head = path.read_text(encoding="utf-8").splitlines()[:3]
+        if any(line.strip() == "# /// script" for line in head):
+            scripts.append(path)
+    return scripts
+
+
+def test_no_pep723_script_ships_the_broken_shebang() -> None:
+    """No repository or template script heads a PEP 723 block with the broken form."""
+    scripts = _pep723_scripts()
+    assert scripts, "expected at least one PEP 723 script in the repository"
+    offenders = [
+        path
+        for path in scripts
+        if path.read_text(encoding="utf-8").startswith(BROKEN_SHEBANG)
+    ]
+    assert not offenders, (
+        "these PEP 723 scripts use `uv run python`, which ignores the inline "
+        f"metadata block: {[str(p) for p in offenders]}"
+    )
+
+
+def test_pep723_scripts_use_the_prescribed_shebang() -> None:
+    """Every PEP 723 script starts with the prescribed --script shebang."""
+    offenders = [
+        path
+        for path in _pep723_scripts()
+        if not path.read_text(encoding="utf-8").startswith(PRESCRIBED_SHEBANG)
+    ]
+    assert not offenders, (
+        "these PEP 723 scripts do not use the prescribed "
+        f"`uv run --script` shebang: {[str(p) for p in offenders]}"
+    )
+
+
+def test_prescribed_shebang_resolves_inline_dependencies(tmp_path: Path) -> None:
+    """A directly executed script under the prescribed shebang imports its deps."""
+    if shutil.which("uv") is None:
+        pytest.skip("uv is not on PATH")
+    script = tmp_path / "probe.py"
+    script.write_text(PROBE_SCRIPT, encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(
+        [str(script)],
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "packaging"


### PR DESCRIPTION
## Summary

This branch corrects the uv script shebang prescribed by the template's shipped scripting standard and used by the repository's PEP 723 scripts, then adds tests guarding the convention. The previous form, `#!/usr/bin/env -S uv run python`, executes the interpreter directly and ignores the PEP 723 inline-metadata block, so a directly invoked script fails at import time wherever its dependencies are not preinstalled — verified empirically. The prescribed form is `#!/usr/bin/env -S uv run --script`.

## Review walkthrough

- [template/docs/scripting-standards.md](https://github.com/leynos/agent-template-rust/blob/fix-uv-script-shebang/template/docs/scripting-standards.md) — the prose prescription gains the rationale, and all code examples switch to `--script`; generated projects now receive the corrected standard.
- [scripts/generate_typos_config.py](https://github.com/leynos/agent-template-rust/blob/fix-uv-script-shebang/scripts/generate_typos_config.py) and [template/scripts/generate_typos_config.py](https://github.com/leynos/agent-template-rust/blob/fix-uv-script-shebang/template/scripts/generate_typos_config.py) — the only PEP 723 scripts in the tree, shebangs corrected.
- [tests/test_scripting_shebang.py](https://github.com/leynos/agent-template-rust/blob/fix-uv-script-shebang/tests/test_scripting_shebang.py) — three tests: static guards that no top-of-file PEP 723 script uses the broken form and that every one uses the prescribed form, plus a behavioural check that executes a temporary script under the prescribed shebang and asserts its inline `packaging` dependency resolves (skipped when `uv` is absent).

## Validation

- `pytest tests/test_scripting_shebang.py`: 3 passed.
- `make spelling`: clean.
- Behavioural proof: the broken shebang fails at import on a clean environment; `--script` mode resolves the block.
