### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/act-validation.yml
+++ b/.github/workflows/act-validation.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install mold linker
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install mold linker
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/template/.github/workflows/act-validation.yml
+++ b/template/.github/workflows/act-validation.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install act
         run: |
           curl -fsSL "https://github.com/nektos/act/releases/download/${ACT_VERSION}/act_Linux_x86_64.tar.gz" |

--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install mold linker
         if: runner.os == 'Linux'
         run: |
@@ -92,7 +92,7 @@ jobs:
           echo "Coverage CFLAGS: -fuse-ld=lld"
           echo "Coverage LDFLAGS: -fuse-ld=lld"
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           RUSTFLAGS: -C link-arg=-fuse-ld=lld
@@ -115,7 +115,7 @@ jobs:
       #       env:
       #         CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
       #       if: env.CS_ACCESS_TOKEN != ''
-      #       uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      #       uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       #       with:
       #         format: lcov
       #         mode: check

--- a/template/.github/workflows/coverage-main.yml
+++ b/template/.github/workflows/coverage-main.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install mold linker
         if: runner.os == 'Linux'
         run: |
@@ -52,7 +52,7 @@ jobs:
           echo "Coverage CFLAGS: -fuse-ld=lld"
           echo "Coverage LDFLAGS: -fuse-ld=lld"
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           RUSTFLAGS: -C link-arg=-fuse-ld=lld
@@ -66,7 +66,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/template/.github/workflows/{% if flavour == 'app' %}release.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if flavour == 'app' %}release.yml{% endif %}.jinja
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
         with:
           persist-credentials: false
-      - uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
       - name: Cache cross binary

--- a/tests/test_template/__snapshots__/test_snapshots.ambr
+++ b/tests/test_template/__snapshots__/test_snapshots.ambr
@@ -21,7 +21,7 @@
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
             }),
             dict({
               'name': 'Install act',
@@ -88,7 +88,7 @@
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
             }),
             dict({
               'if': "runner.os == 'Linux'",
@@ -207,7 +207,7 @@
                 'RUSTFLAGS': '-C link-arg=-fuse-ld=lld',
               }),
               'name': 'Test and Measure Coverage',
-              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
               'with': dict({
                 'format': 'lcov',
                 'output-path': 'lcov.info',
@@ -249,7 +249,7 @@
             }),
             dict({
               'name': 'Setup Rust',
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
             }),
             dict({
               'if': "runner.os == 'Linux'",
@@ -288,7 +288,7 @@
                 'RUSTFLAGS': '-C link-arg=-fuse-ld=lld',
               }),
               'name': 'Test and Measure Coverage',
-              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
               'with': dict({
                 'format': 'lcov',
                 'output-path': 'lcov.info',
@@ -301,7 +301,7 @@
               }),
               'if': "env.CS_ACCESS_TOKEN != ''",
               'name': 'Upload coverage data to CodeScene',
-              'uses': 'leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
               'with': dict({
                 'access-token': '${{ env.CS_ACCESS_TOKEN }}',
                 'format': 'lcov',
@@ -444,7 +444,7 @@
               }),
             }),
             dict({
-              'uses': 'leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd',
+              'uses': 'leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57',
               'with': dict({
                 'toolchain': 'stable',
               }),


### PR DESCRIPTION
## Summary

- Advance every `leynos/shared-actions` pin to `18bed1ca49a6de3d8882bd72635a32ae3f023d57` (shared-actions main HEAD), in both this repo's own `.github/workflows/*.yml` and the copier template sources under `template/` (including `.jinja` workflow files), so newly generated projects start at the same pin.
- Regenerate the affected structured-file syrupy snapshot (`tests/test_template/__snapshots__/test_snapshots.ambr`) so it matches the newly rendered template output.
- Picks up the coverage-ratchet baseline-advance fix and the symmetric ±1pp dead-band (shared-actions#353), plus routine follow-ups (#354, #356 whitaker-installer 0.2.6, #344).

## Review walkthrough

- `.github/workflows/{ci,act-validation,dependabot-automerge}.yml`: repo's own CI pins bumped.
- `template/.github/workflows/{act-validation,coverage-main}.yml`, `template/.github/workflows/ci.yml.jinja`, and `template/.github/workflows/{% if flavour == 'app' %}release.yml{% endif %}.jinja`: template source pins bumped (including one commented-out example line in `ci.yml.jinja`), keeping templating syntax intact.
- `tests/test_template/__snapshots__/test_snapshots.ambr`: updated to the new pin so the generated-file snapshot test stays green.
- Left `tests/test_helpers.py:440` untouched: it is a synthetic fixture for a shape-only contract test (`assert_ci_coverage_action_contract`), not a real pin.
- A repo-wide grep confirms no other 40-hex shared-actions SHA remains outside that one fixture.

## Validation

- [x] `uvx --with pytest-copier --with pyyaml --with syrupy --with make-parser --with hypothesis pytest tests/test_template/test_snapshots.py` — snapshot passes with the new pin.
- [x] `make test` — 58 passed, 1 skipped, 3 pre-existing failures in `test_lint_targets.py::test_makefile_resolves_whitaker_fallback` confirmed present on `main` before this change (unrelated to the pin bump; environment-dependent `make`/Whitaker resolution).
- [ ] CI green on this branch
